### PR TITLE
Migrate build tool to SBT 2.0.0

### DIFF
--- a/.sbtopts
+++ b/.sbtopts
@@ -1,3 +1,1 @@
--batch
--Dsbt.supershell=false
 -Dsbt.color=always

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ ThisBuild / licenses := List("Apache-2.0" -> url("http://www.apache.org/licenses
 ThisBuild / versionScheme := Some("semver-spec")
 
 ThisBuild / scalaVersion := "2.12.21"
-ThisBuild / crossScalaVersions += "3.8.4"
+ThisBuild / crossScalaVersions := Seq(scalaVersion.value, "3.8.4")
 
 ThisBuild / scalacOptions ++= Seq("-deprecation", "-feature", "-unchecked")
 ThisBuild / scalacOptions ++= (CrossVersion.partialVersion(scalaVersion.value) match {

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.12.11
+sbt.version=2.0.0

--- a/test.sh
+++ b/test.sh
@@ -2,4 +2,4 @@
 
 set -euxo pipefail
 
-sbt scalafmtSbtCheck scalafmtCheckAll +clean +coverage +test +coverageSummary +coverageAggregate
+sbt "scalafmtSbtCheck; scalafmtCheckAll; cleanFull; +coverage; +test; +coverageSummary; +coverageAggregate"


### PR DESCRIPTION
- Update project/build.properties to sbt.version=2.0.0
- Use Scala 3.8.4 (required for TASTy compatibility with SBT 2.0.0)
- Add @transient to task keys to opt out of SBT 2 distributed caching
- Fix eta-expansion syntax to use (_, _) placeholders (Scala 3 compat)
- Fix crossScalaVersions to use := Seq(scalaVersion.value, "3.8.4")
- Fix test.sh: use cleanFull + semicolon-separated commands for SBT 2
- Fix .sbtopts: remove -batch and -Dsbt.supershell=false (SBT 2 exits automatically and colors are tied to super shell)