### PR TITLE
Fix SBT 2.0 set command crash by renaming project val

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -37,7 +37,8 @@ ThisBuild / scmInfo := Some(
 
 ThisBuild / dynverSonatypeSnapshots := true
 
-val plugin = project
+val core = project
+  .in(file("plugin"))
   .enablePlugins(SbtPlugin, ScoverageSummaryPlugin)
   .settings(
     name := "sbt-scoverage-summary",


### PR DESCRIPTION
SBT 2.0 generates Scala 3 code referencing subproject names when evaluating any `set` expression. The name `plugin` conflicts with the generated wrapper, causing every `set` (and `coverage`, `+task`) to fail.