### PR TITLE
Make threshold semantics coherent and validate them

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,10 @@ sbt +publishLocal          # both rows to ~/.ivy2/local
 Project ids come from `sbt-projectmatrix`: `plugin` and `plugin2_12`, aggregated by `sbt-scoverage-summary-root`.
 `cleanFull` in `test.sh` is sbt 2.0-only and has no sbt 1.x equivalent.
 
+sbt 2.0 caches test results and delegates `test` to `testQuick`, so a re-run with no source changes prints
+`No tests to run for ... / testQuick` and `Passed: Total 0` — that is a cache hit, not a missing test setup, and
+plain `clean` does not invalidate it. Use `testOnly` to force an actual run.
+
 ## Architecture
 
 ### Two plugins, split by trigger

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This project uses it itself, and could be used as a reference for usage
     * Multi - always show multimodule project layout.
     * Total - show only total summary value.
 * coverageSummaryLowThreshold - type is Float, this value is used
-  to color in red when coverage rate is lesser or equal than this value.
+  to color in red when coverage rate is lesser than this value.
 * coverageSummaryHighThreshold - type is Float, this value is used
   to color in green when coverage rate is greater or equal than this value.
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ This project uses it itself, and could be used as a reference for usage
 * coverageSummaryHighThreshold - type is Float, this value is used
   to color in green when coverage rate is greater or equal than this value.
 
+  Both thresholds must satisfy `0 <= low <= high <= 100`, otherwise `coverageSummary` fails.
+  Equal thresholds are allowed and produce a two-color scale with no intermediate color.
+
 ## Usage
 
 ### plugins.sbt

--- a/plugin/src/main/scala/h8io/sbt/scoverage/Format.scala
+++ b/plugin/src/main/scala/h8io/sbt/scoverage/Format.scala
@@ -105,7 +105,7 @@ object Format {
       else {
         val rate = invoked.toFloat / total * 100
         val color =
-          if (rate <= lowThreshold) "#f00"
+          if (rate < lowThreshold) "#f00"
           else if (rate < highThreshold) "#ff0"
           else "#0f0"
         f"$$\\color{$color}$rate%2.02f\\%%$$"

--- a/plugin/src/main/scala/h8io/sbt/scoverage/ScoverageSummaryPlugin.scala
+++ b/plugin/src/main/scala/h8io/sbt/scoverage/ScoverageSummaryPlugin.scala
@@ -27,6 +27,9 @@ object ScoverageSummaryPlugin extends AutoPlugin {
       coverageSummaryHighThreshold := 75,
       coverageSummaryLayout := Layout.Auto,
       coverageSummary := {
+        val lowThreshold = coverageSummaryLowThreshold.value
+        val highThreshold = coverageSummaryHighThreshold.value
+        validateThresholds(lowThreshold, highThreshold) foreach (message => throw new MessageOnlyException(message))
         val projects = ScoverageProjectSummaryPlugin.summary
           .all(ScopeFilter(inAggregates(ThisProject, includeRoot = true)))
           .value
@@ -35,11 +38,7 @@ object ScoverageSummaryPlugin extends AutoPlugin {
           case Some(total) =>
             for {
               format <- coverageSummaryFormat.value
-              render = format.render(
-                coverageSummaryLayout.value,
-                coverageSummaryLowThreshold.value,
-                coverageSummaryHighThreshold.value
-              )(_, _)
+              render = format.render(coverageSummaryLayout.value, lowThreshold, highThreshold)(_, _)
               filename = crossTarget.value / "scoverage-summary" / format.filename
               summary =
                 "## " + name.value + " (" + thisProjectRef.value.project + ")\n### Scala " + scalaBinaryVersion.value +
@@ -61,4 +60,16 @@ object ScoverageSummaryPlugin extends AutoPlugin {
   // Visible for testing
   private[scoverage] def total(projects: Seq[ProjectSummary]): Option[Metrics] =
     projects.iterator.map(_.metrics).reduceOption(_ + _)
+
+  // Visible for testing
+  // Coverage rates are always within [0, 100], so a threshold outside that range makes a color unreachable,
+  // and a low threshold above the high one leaves no room for the intermediate color at all.
+  // Equal thresholds are allowed: they define a two-color scale without an intermediate band.
+  private[scoverage] def validateThresholds(lowThreshold: Float, highThreshold: Float): Option[String] =
+    if (0 <= lowThreshold && lowThreshold <= highThreshold && highThreshold <= 100) None
+    else
+      Some(
+        s"Inconsistent thresholds: coverageSummaryLowThreshold ($lowThreshold) and " +
+          s"coverageSummaryHighThreshold ($highThreshold) must satisfy 0 <= low <= high <= 100"
+      )
 }

--- a/plugin/src/test/scala/h8io/sbt/scoverage/ScoverageSummaryPluginTest.scala
+++ b/plugin/src/test/scala/h8io/sbt/scoverage/ScoverageSummaryPluginTest.scala
@@ -16,4 +16,32 @@ class ScoverageSummaryPluginTest extends AnyFlatSpec with Matchers {
         Nil
     ) shouldBe Some(Metrics(19, 14, 9, 27, 22))
   }
+
+  "validateThresholds" should "accept a low threshold below the high one" in {
+    ScoverageSummaryPlugin.validateThresholds(50, 75) shouldBe None
+  }
+
+  it should "accept equal thresholds as a two-color scale" in {
+    ScoverageSummaryPlugin.validateThresholds(60, 60) shouldBe None
+  }
+
+  it should "accept the whole range of possible coverage rates" in {
+    ScoverageSummaryPlugin.validateThresholds(0, 100) shouldBe None
+  }
+
+  it should "reject a low threshold above the high one" in {
+    ScoverageSummaryPlugin.validateThresholds(75, 50) should not be empty
+  }
+
+  it should "reject a negative low threshold" in {
+    ScoverageSummaryPlugin.validateThresholds(-1, 75) should not be empty
+  }
+
+  it should "reject a high threshold above the maximal coverage rate" in {
+    ScoverageSummaryPlugin.validateThresholds(50, 101) should not be empty
+  }
+
+  it should "reject a threshold which is not a number" in {
+    ScoverageSummaryPlugin.validateThresholds(Float.NaN, 75) should not be empty
+  }
 }


### PR DESCRIPTION
## Summary

Two related changes to how `coverageSummaryLowThreshold` and `coverageSummaryHighThreshold` behave.

**Strict low threshold.** Red was applied when `rate <= lowThreshold`, while green was applied when `rate >= highThreshold`. The two ends disagreed on who owns the boundary value. Red is now applied when `rate < lowThreshold`, so both thresholds read the same way: reaching a threshold counts in favour of the project.

A side effect is that `low == high` becomes a clean two-colour scale — at a rate exactly on the boundary neither `rate < low` nor `rate < high` holds, so the cell is green. Previously the boundary value went to red despite what `high` said.

**Threshold validation.** `coverageSummary` now fails unless `0 <= low <= high <= 100`:

- an inverted pair leaves the yellow branch (`rate >= low && rate < high`) unreachable by construction;
- coverage rates always lie within `[0, 100]`, so a threshold outside that range makes one of the colours unreachable — `high > 100` kills green, `low < 0` kills red;
- `NaN` is rejected as a side effect of the same comparison chain, which would otherwise paint everything green.

`0` and `100` themselves stay valid: `low := 0` disables red, `high := 100` demands full coverage for green, and exactly 100% is representable without an epsilon since dividing equal `Int`s is exact in IEEE-754.

Validation runs before any project data is read, so a misconfiguration cannot write a misleading report.

## Test plan

- 7 new unit tests on `validateThresholds` covering both sides of the inequality, equality, the range bounds and `NaN`
- `scalafmtSbtCheck`, `scalafmtCheckAll` clean
- both matrix rows compile (`plugin` on Scala 3.8.4 / sbt 2.0.0, `plugin2_12` on Scala 2.12.21 / sbt 1.8.0, both warning-fatal) and all 16 tests pass on each

`sbt.MessageOnlyException` was checked to resolve on both sbt versions before being used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)