### PR TITLE
Split coverage thresholds per metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,19 @@ This project uses it itself, and could be used as a reference for usage
       another one for multimodule projects.
     * Multi - always show multimodule project layout.
     * Total - show only total summary value.
-* coverageSummaryLowThreshold - type is Float, this value is used
-  to color in red when coverage rate is lesser than this value.
-* coverageSummaryHighThreshold - type is Float, this value is used
-  to color in green when coverage rate is greater or equal than this value.
+* coverageSummaryStmtLowThreshold, coverageSummaryBranchLowThreshold - type is Float,
+  this value is used to color in red when the corresponding coverage rate
+  is lesser than this value.
+* coverageSummaryStmtHighThreshold, coverageSummaryBranchHighThreshold - type is Float,
+  this value is used to color in green when the corresponding coverage rate
+  is greater or equal than this value.
 
-  Both thresholds must satisfy `0 <= low <= high <= 100`, otherwise `coverageSummary` fails.
-  Equal thresholds are allowed and produce a two-color scale with no intermediate color.
+  Statement and branch coverage are separate metrics whose rates are not correlated,
+  so each of them has its own pair of thresholds.
+
+  Within a metric the thresholds must satisfy `0 <= low <= high <= 100`,
+  otherwise `coverageSummary` fails. Equal thresholds are allowed
+  and produce a two-color scale with no intermediate color.
 
 ## Usage
 

--- a/plugin/src/main/scala/h8io/sbt/scoverage/Format.scala
+++ b/plugin/src/main/scala/h8io/sbt/scoverage/Format.scala
@@ -5,23 +5,23 @@ import scala.xml.Elem
 trait Format {
   def name: String
 
-  private[scoverage] final def render(layout: Layout, lowThreshold: Float, highThreshold: Float)(
+  private[scoverage] final def render(layout: Layout, statements: Thresholds, branches: Thresholds)(
       projects: Seq[ProjectSummary],
       total: Metrics
   ): String =
     layout match {
       case Layout.Auto =>
-        if (projects.length == 1) render(lowThreshold, highThreshold, projects.head)
-        else render(lowThreshold, highThreshold, projects, total)
-      case Layout.Multi => render(lowThreshold, highThreshold, projects, total)
-      case Layout.Total => render(lowThreshold, highThreshold, total)
+        if (projects.length == 1) render(statements, branches, projects.head)
+        else render(statements, branches, projects, total)
+      case Layout.Multi => render(statements, branches, projects, total)
+      case Layout.Total => render(statements, branches, total)
     }
 
-  def render(lowThreshold: Float, highThreshold: Float, projects: Seq[ProjectSummary], total: Metrics): String
+  def render(statements: Thresholds, branches: Thresholds, projects: Seq[ProjectSummary], total: Metrics): String
 
-  def render(lowThreshold: Float, highThreshold: Float, project: ProjectSummary): String
+  def render(statements: Thresholds, branches: Thresholds, project: ProjectSummary): String
 
-  def render(lowThreshold: Float, highThreshold: Float, total: Metrics): String
+  def render(statements: Thresholds, branches: Thresholds, total: Metrics): String
 
   def filename: String
 }
@@ -30,8 +30,9 @@ object Format {
   case object GitHubFlavoredMarkdown extends Format {
     val name = "GitHub flavored markdown"
 
-    def render(lowThreshold: Float, highThreshold: Float, projects: Seq[ProjectSummary], total: Metrics): String = {
-      val valueRender = render(lowThreshold, highThreshold)(_, _)
+    def render(statements: Thresholds, branches: Thresholds, projects: Seq[ProjectSummary], total: Metrics): String = {
+      val statementRender = render(statements)(_, _)
+      val branchRender = render(branches)(_, _)
       <table>
         <thead>
           <tr>
@@ -52,10 +53,10 @@ object Format {
             <td align="right">{m.statements}</td>
             <td align="right">{m.invokedStatements}</td>
             <td align="right">{m.ignoredStatements}</td>
-            <td align="right">{valueRender(m.invokedStatements, m.statements)}</td>
+            <td align="right">{statementRender(m.invokedStatements, m.statements)}</td>
             <td align="right">{m.branches}</td>
             <td align="right">{m.invokedBranches}</td>
-            <td align="right">{valueRender(m.invokedBranches, m.branches)}</td>
+            <td align="right">{branchRender(m.invokedBranches, m.branches)}</td>
           </tr>
         }
       }
@@ -66,47 +67,48 @@ object Format {
             <td align="right">{total.statements}</td>
             <td align="right">{total.invokedStatements}</td>
             <td align="right">{total.ignoredStatements}</td>
-            <td align="right">{valueRender(total.invokedStatements, total.statements)}</td>
+            <td align="right">{statementRender(total.invokedStatements, total.statements)}</td>
             <td align="right">{total.branches}</td>
             <td align="right">{total.invokedBranches}</td>
-            <td align="right">{valueRender(total.invokedBranches, total.branches)}</td>
+            <td align="right">{branchRender(total.invokedBranches, total.branches)}</td>
             </tr>
           </tfoot>
       </table>.toString()
     }
 
-    def render(lowThreshold: Float, highThreshold: Float, project: ProjectSummary): String =
+    def render(statements: Thresholds, branches: Thresholds, project: ProjectSummary): String =
       <table>
         <thead>
           <tr><th rowspan="2">Project</th><th>Name</th><td align="center">{project.name}</td></tr>
           <tr><th>ID</th><td align="center">{project.id}</td></tr>
         </thead>
-        {renderMetricsBody(lowThreshold, highThreshold, project.metrics)}
+        {renderMetricsBody(statements, branches, project.metrics)}
       </table>.toString()
 
-    def render(lowThreshold: Float, highThreshold: Float, metrics: Metrics): String =
-      <table>{renderMetricsBody(lowThreshold, highThreshold, metrics)}</table>.toString()
+    def render(statements: Thresholds, branches: Thresholds, metrics: Metrics): String =
+      <table>{renderMetricsBody(statements, branches, metrics)}</table>.toString()
 
-    private def renderMetricsBody(lowThreshold: Float, highThreshold: Float, metrics: Metrics): Elem = {
-      val valueRender = render(lowThreshold, highThreshold)(_, _)
+    private def renderMetricsBody(statements: Thresholds, branches: Thresholds, metrics: Metrics): Elem = {
+      val statementRender = render(statements)(_, _)
+      val branchRender = render(branches)(_, _)
       <tbody>
         <tr><th rowspan="4">Statements</th><th>Total</th><td align="right">{metrics.statements}</td></tr>
         <tr><th>Invoked</th><td align="right">{metrics.invokedStatements}</td></tr>
         <tr><th>Ignored</th><td align="right">{metrics.ignoredStatements}</td></tr>
-        <tr><th>Rate</th><td align="right">{valueRender(metrics.invokedStatements, metrics.statements)}</td></tr>
+        <tr><th>Rate</th><td align="right">{statementRender(metrics.invokedStatements, metrics.statements)}</td></tr>
         <tr><th rowspan="3">Branches</th><th>Total</th><td align="right">{metrics.branches}</td></tr>
         <tr><th>Invoked</th><td align="right">{metrics.invokedBranches}</td></tr>
-        <tr><th>Rate</th><td align="right">{valueRender(metrics.invokedBranches, metrics.branches)}</td></tr>
+        <tr><th>Rate</th><td align="right">{branchRender(metrics.invokedBranches, metrics.branches)}</td></tr>
       </tbody>
     }
 
-    private def render(lowThreshold: Float, highThreshold: Float)(invoked: Int, total: Int): String =
+    private def render(thresholds: Thresholds)(invoked: Int, total: Int): String =
       if (total == 0) "$\\textemdash$"
       else {
         val rate = invoked.toFloat / total * 100
         val color =
-          if (rate < lowThreshold) "#f00"
-          else if (rate < highThreshold) "#ff0"
+          if (rate < thresholds.low) "#f00"
+          else if (rate < thresholds.high) "#ff0"
           else "#0f0"
         f"$$\\color{$color}$rate%2.02f\\%%$$"
       }

--- a/plugin/src/main/scala/h8io/sbt/scoverage/ScoverageSummaryPlugin.scala
+++ b/plugin/src/main/scala/h8io/sbt/scoverage/ScoverageSummaryPlugin.scala
@@ -9,8 +9,10 @@ object ScoverageSummaryPlugin extends AutoPlugin {
   object autoImport {
     @transient val coverageSummary = taskKey[Unit]("Generate scoverage summary")
     val coverageSummaryFormat = settingKey[Set[Format]]("Summary format")
-    val coverageSummaryLowThreshold = settingKey[Float]("Coverage low threshold (red)")
-    val coverageSummaryHighThreshold = settingKey[Float]("Coverage high threshold (green)")
+    val coverageSummaryStmtLowThreshold = settingKey[Float]("Statement coverage low threshold (red)")
+    val coverageSummaryStmtHighThreshold = settingKey[Float]("Statement coverage high threshold (green)")
+    val coverageSummaryBranchLowThreshold = settingKey[Float]("Branch coverage low threshold (red)")
+    val coverageSummaryBranchHighThreshold = settingKey[Float]("Branch coverage high threshold (green)")
     val coverageSummaryLayout = settingKey[Layout]("Summary layout")
   }
   import autoImport.*
@@ -23,13 +25,16 @@ object ScoverageSummaryPlugin extends AutoPlugin {
     Seq(
       coverageSummary / aggregate := false,
       coverageSummaryFormat := Set(Format.GitHubFlavoredMarkdown),
-      coverageSummaryLowThreshold := 50,
-      coverageSummaryHighThreshold := 75,
+      coverageSummaryStmtLowThreshold := 50,
+      coverageSummaryStmtHighThreshold := 75,
+      coverageSummaryBranchLowThreshold := 50,
+      coverageSummaryBranchHighThreshold := 75,
       coverageSummaryLayout := Layout.Auto,
       coverageSummary := {
-        val lowThreshold = coverageSummaryLowThreshold.value
-        val highThreshold = coverageSummaryHighThreshold.value
-        validateThresholds(lowThreshold, highThreshold) foreach (message => throw new MessageOnlyException(message))
+        val statements = Thresholds(coverageSummaryStmtLowThreshold.value, coverageSummaryStmtHighThreshold.value)
+        val branches = Thresholds(coverageSummaryBranchLowThreshold.value, coverageSummaryBranchHighThreshold.value)
+        val errors = validateThresholds("Stmt", statements).toSeq ++ validateThresholds("Branch", branches)
+        if (errors.nonEmpty) throw new MessageOnlyException(errors.mkString("\n"))
         val projects = ScoverageProjectSummaryPlugin.summary
           .all(ScopeFilter(inAggregates(ThisProject, includeRoot = true)))
           .value
@@ -38,7 +43,7 @@ object ScoverageSummaryPlugin extends AutoPlugin {
           case Some(total) =>
             for {
               format <- coverageSummaryFormat.value
-              render = format.render(coverageSummaryLayout.value, lowThreshold, highThreshold)(_, _)
+              render = format.render(coverageSummaryLayout.value, statements, branches)(_, _)
               filename = crossTarget.value / "scoverage-summary" / format.filename
               summary =
                 "## " + name.value + " (" + thisProjectRef.value.project + ")\n### Scala " + scalaBinaryVersion.value +
@@ -65,11 +70,12 @@ object ScoverageSummaryPlugin extends AutoPlugin {
   // Coverage rates are always within [0, 100], so a threshold outside that range makes a color unreachable,
   // and a low threshold above the high one leaves no room for the intermediate color at all.
   // Equal thresholds are allowed: they define a two-color scale without an intermediate band.
-  private[scoverage] def validateThresholds(lowThreshold: Float, highThreshold: Float): Option[String] =
-    if (0 <= lowThreshold && lowThreshold <= highThreshold && highThreshold <= 100) None
+  // `metric` is the setting key infix, so that the message points at the keys the user has to fix.
+  private[scoverage] def validateThresholds(metric: String, thresholds: Thresholds): Option[String] =
+    if (0 <= thresholds.low && thresholds.low <= thresholds.high && thresholds.high <= 100) None
     else
       Some(
-        s"Inconsistent thresholds: coverageSummaryLowThreshold ($lowThreshold) and " +
-          s"coverageSummaryHighThreshold ($highThreshold) must satisfy 0 <= low <= high <= 100"
+        s"Inconsistent thresholds: coverageSummary${metric}LowThreshold (${thresholds.low}) and " +
+          s"coverageSummary${metric}HighThreshold (${thresholds.high}) must satisfy 0 <= low <= high <= 100"
       )
 }

--- a/plugin/src/main/scala/h8io/sbt/scoverage/Thresholds.scala
+++ b/plugin/src/main/scala/h8io/sbt/scoverage/Thresholds.scala
@@ -1,0 +1,7 @@
+package h8io.sbt.scoverage
+
+/** Coverage rate boundaries of a single metric: below `low` the rate is rendered as bad, starting from `high` it is
+  * rendered as good, in between as intermediate. Statement and branch rates are unrelated to each other, so every
+  * metric carries its own pair.
+  */
+final case class Thresholds(low: Float, high: Float)

--- a/plugin/src/test/scala/h8io/sbt/scoverage/FormatTest.scala
+++ b/plugin/src/test/scala/h8io/sbt/scoverage/FormatTest.scala
@@ -5,8 +5,8 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 class FormatTest extends AnyFlatSpec with Matchers with MockFactory {
-  private val lowThreshold: Float = 0.3f
-  private val highThreshold: Float = 0.8f
+  private val statements = Thresholds(0.3f, 0.8f)
+  private val branches = Thresholds(0.1f, 0.5f)
 
   private val project = ProjectSummary("root", "single", Metrics(12, 7, 1, 10, 5))
   private val projects = Seq(
@@ -18,57 +18,67 @@ class FormatTest extends AnyFlatSpec with Matchers with MockFactory {
   "render" should s"invoke the correct method for a single project when layout is ${Layout.Auto}" in {
     val format = mock[Format]
     val result = "single project summary with auto layout"
-    (format.render(_: Float, _: Float, _: ProjectSummary)).expects(lowThreshold, highThreshold, project).returns(result)
-    format.render(Layout.Auto, lowThreshold, highThreshold)(project :: Nil, project.metrics) shouldEqual result
+    (format
+      .render(_: Thresholds, _: Thresholds, _: ProjectSummary))
+      .expects(statements, branches, project)
+      .returns(result)
+    format.render(Layout.Auto, statements, branches)(project :: Nil, project.metrics) shouldEqual result
   }
 
   it should s"invoke the correct method for multiple projects when layout is ${Layout.Auto}" in {
     val format = mock[Format]
     val result = "multiproject summary with auto layout"
     (format
-      .render(_: Float, _: Float, _: Seq[ProjectSummary], _: Metrics))
-      .expects(lowThreshold, highThreshold, projects, metrics)
+      .render(_: Thresholds, _: Thresholds, _: Seq[ProjectSummary], _: Metrics))
+      .expects(statements, branches, projects, metrics)
       .returns(result)
-    format.render(Layout.Auto, lowThreshold, highThreshold)(projects, metrics) shouldEqual result
+    format.render(Layout.Auto, statements, branches)(projects, metrics) shouldEqual result
   }
 
   it should s"invoke the correct method for a single project when layout is ${Layout.Multi}" in {
     val format = mock[Format]
     val result = s"single project summary with layout ${Layout.Multi}"
     (format
-      .render(_: Float, _: Float, _: Seq[ProjectSummary], _: Metrics))
-      .expects(lowThreshold, highThreshold, project :: Nil, project.metrics)
+      .render(_: Thresholds, _: Thresholds, _: Seq[ProjectSummary], _: Metrics))
+      .expects(statements, branches, project :: Nil, project.metrics)
       .returns(result)
-    format.render(Layout.Multi, lowThreshold, highThreshold)(project :: Nil, project.metrics) shouldEqual result
+    format.render(Layout.Multi, statements, branches)(project :: Nil, project.metrics) shouldEqual result
   }
 
   it should s"invoke the correct method for multiple projects when layout is ${Layout.Multi}" in {
     val format = mock[Format]
     val result = s"multiproject summary with layout ${Layout.Multi}"
     (format
-      .render(_: Float, _: Float, _: Seq[ProjectSummary], _: Metrics))
-      .expects(lowThreshold, highThreshold, projects, metrics)
+      .render(_: Thresholds, _: Thresholds, _: Seq[ProjectSummary], _: Metrics))
+      .expects(statements, branches, projects, metrics)
       .returns(result)
-    format.render(Layout.Multi, lowThreshold, highThreshold)(projects, metrics) shouldEqual result
+    format.render(Layout.Multi, statements, branches)(projects, metrics) shouldEqual result
   }
 
   it should s"invoke the correct method for a single project when layout is ${Layout.Total}" in {
     val format = mock[Format]
     val result = s"single project summary with layout ${Layout.Total}"
     (format
-      .render(_: Float, _: Float, _: Metrics))
-      .expects(lowThreshold, highThreshold, project.metrics)
+      .render(_: Thresholds, _: Thresholds, _: Metrics))
+      .expects(statements, branches, project.metrics)
       .returns(result)
-    format.render(Layout.Total, lowThreshold, highThreshold)(project :: Nil, project.metrics) shouldEqual result
+    format.render(Layout.Total, statements, branches)(project :: Nil, project.metrics) shouldEqual result
   }
 
   it should s"invoke the correct method for multiple projects when layout is ${Layout.Total}" in {
     val format = mock[Format]
     val result = s"multiproject summary with layout ${Layout.Total}"
     (format
-      .render(_: Float, _: Float, _: Metrics))
-      .expects(lowThreshold, highThreshold, metrics)
+      .render(_: Thresholds, _: Thresholds, _: Metrics))
+      .expects(statements, branches, metrics)
       .returns(result)
-    format.render(Layout.Total, lowThreshold, highThreshold)(projects, metrics) shouldEqual result
+    format.render(Layout.Total, statements, branches)(projects, metrics) shouldEqual result
+  }
+
+  s"${Format.GitHubFlavoredMarkdown.name}" should "color statements and branches by their own thresholds" in {
+    val equalRates = Metrics(10, 5, 0, 10, 5)
+    val rendered = Format.GitHubFlavoredMarkdown.render(Thresholds(60, 80), Thresholds(20, 40), equalRates)
+    rendered should include("\\color{#f00}50.00")
+    rendered should include("\\color{#0f0}50.00")
   }
 }

--- a/plugin/src/test/scala/h8io/sbt/scoverage/ScoverageSummaryPluginTest.scala
+++ b/plugin/src/test/scala/h8io/sbt/scoverage/ScoverageSummaryPluginTest.scala
@@ -1,9 +1,10 @@
 package h8io.sbt.scoverage
 
+import org.scalatest.OptionValues
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-class ScoverageSummaryPluginTest extends AnyFlatSpec with Matchers {
+class ScoverageSummaryPluginTest extends AnyFlatSpec with Matchers with OptionValues {
   "total" should "return None for an empty sequence" in {
     ScoverageSummaryPlugin.total(Nil) shouldBe None
   }
@@ -18,30 +19,36 @@ class ScoverageSummaryPluginTest extends AnyFlatSpec with Matchers {
   }
 
   "validateThresholds" should "accept a low threshold below the high one" in {
-    ScoverageSummaryPlugin.validateThresholds(50, 75) shouldBe None
+    ScoverageSummaryPlugin.validateThresholds("Stmt", Thresholds(50, 75)) shouldBe None
   }
 
   it should "accept equal thresholds as a two-color scale" in {
-    ScoverageSummaryPlugin.validateThresholds(60, 60) shouldBe None
+    ScoverageSummaryPlugin.validateThresholds("Stmt", Thresholds(60, 60)) shouldBe None
   }
 
   it should "accept the whole range of possible coverage rates" in {
-    ScoverageSummaryPlugin.validateThresholds(0, 100) shouldBe None
+    ScoverageSummaryPlugin.validateThresholds("Stmt", Thresholds(0, 100)) shouldBe None
   }
 
   it should "reject a low threshold above the high one" in {
-    ScoverageSummaryPlugin.validateThresholds(75, 50) should not be empty
+    ScoverageSummaryPlugin.validateThresholds("Stmt", Thresholds(75, 50)) should not be empty
   }
 
   it should "reject a negative low threshold" in {
-    ScoverageSummaryPlugin.validateThresholds(-1, 75) should not be empty
+    ScoverageSummaryPlugin.validateThresholds("Stmt", Thresholds(-1, 75)) should not be empty
   }
 
   it should "reject a high threshold above the maximal coverage rate" in {
-    ScoverageSummaryPlugin.validateThresholds(50, 101) should not be empty
+    ScoverageSummaryPlugin.validateThresholds("Stmt", Thresholds(50, 101)) should not be empty
   }
 
   it should "reject a threshold which is not a number" in {
-    ScoverageSummaryPlugin.validateThresholds(Float.NaN, 75) should not be empty
+    ScoverageSummaryPlugin.validateThresholds("Stmt", Thresholds(Float.NaN, 75)) should not be empty
+  }
+
+  it should "point at the setting keys of the metric being validated" in {
+    ScoverageSummaryPlugin.validateThresholds("Branch", Thresholds(75, 50)).value should (
+      include("coverageSummaryBranchLowThreshold") and include("coverageSummaryBranchHighThreshold")
+    )
   }
 }


### PR DESCRIPTION
## Summary

`coverageSummaryLowThreshold` / `coverageSummaryHighThreshold` applied to statement and branch rates alike. Measured on this repository, those two rates currently sit at **9.90%** and **53.85%** — a factor of five apart, on the same code. No single pair of thresholds is meaningful for both: at 50/75 statements are red and branches yellow; lowered enough to be fair to statements, the pair says nothing about branches.

The divergence is not an accident of this repository either. In scoverage `branches = statements.filter(_.branch)`, so branches are a subset of statements rather than an independent axis, and the ratio between the two rates depends entirely on where the untested code sits. Here the untested mass is sbt task bodies — long straight-line code with almost no conditionals — while the tested part is the pure functions, which is where the conditionals live.

Each metric therefore gets its own pair:

| replaced | by |
|---|---|
| `coverageSummaryLowThreshold` | `coverageSummaryStmtLowThreshold`, `coverageSummaryBranchLowThreshold` |
| `coverageSummaryHighThreshold` | `coverageSummaryStmtHighThreshold`, `coverageSummaryBranchHighThreshold` |

Defaults are unchanged at 50 / 75 for both metrics, so behaviour out of the box is the same as before.

### Notes

- The pair travels as a `Thresholds` value rather than two bare `Float`s. Four positional arguments of the same type in `Format.render` would have been trivial to transpose, and the mistake would have been silent. Setting keys stay flat `Float`s so that a single one can still be overridden with a one-liner.
- Validation now runs per metric and reports **every** violation at once rather than stopping at the first, and the message names the keys of the metric that is actually wrong.

## Breaking change

The two old keys are gone with no compatibility shim. Under `versionScheme := semver-spec` this is a major release.

## Test plan

- 18 unit tests pass on both matrix rows (`plugin` on Scala 3.8.4 / sbt 2.0.0, `plugin2_12` on Scala 2.12.21 / sbt 1.8.0, both warning-fatal); `scalafmtSbtCheck` and `scalafmtCheckAll` clean
- new test asserts the two metrics get different colours at an identical rate
- new test asserts the validation message names the keys of the failing metric
- verified end to end on a scratch project against a locally published build, since this repository's own build consumes the released plugin and cannot exercise the change: at an identical 0.00% rate, statements rendered `#0f0` under thresholds 0/0 while branches rendered `#f00` under 50/75
- verified there that a doubly-invalid configuration reports both metrics in one go

🤖 Generated with [Claude Code](https://claude.com/claude-code)