### PR TITLE
Resolve coverage thresholds per module

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,35 @@ This project uses it itself, and could be used as a reference for usage
   otherwise `coverageSummary` fails. Equal thresholds are allowed
   and produce a two-color scale with no intermediate color.
 
+### Per-module thresholds
+
+Thresholds are resolved separately for every module, so each row of the report
+can be judged by its own values. There is nothing to enable: this is the regular
+SBT `project -> ThisBuild -> Global` delegation, and the defaults above live in
+the global scope.
+
+```sbt
+// applies to every module which does not say otherwise
+ThisBuild / coverageSummaryStmtLowThreshold := 60
+
+// this one is held to a higher standard
+lazy val core = project.settings(coverageSummaryStmtLowThreshold := 90)
+
+// and this one is not expected to be covered at all
+lazy val examples = project.settings(coverageSummaryStmtLowThreshold := 0)
+```
+
+The keys can be scoped to any module, including modules where
+`ScoverageSummaryPlugin` itself is not enabled.
+
+Every module is validated, and a report which is inconsistent in several modules
+lists all of them at once, each prefixed with the module id.
+
+The total row is judged by the thresholds of the aggregating project. Its color
+is therefore not derivable from the colors of the rows above it: modules that are
+all green can still add up to a yellow total, since the total is a different
+number measured against a different pair of thresholds.
+
 ## Usage
 
 ### plugins.sbt

--- a/plugin/src/main/scala/h8io/sbt/scoverage/Format.scala
+++ b/plugin/src/main/scala/h8io/sbt/scoverage/Format.scala
@@ -5,23 +5,20 @@ import scala.xml.Elem
 trait Format {
   def name: String
 
-  private[scoverage] final def render(layout: Layout, statements: Thresholds, branches: Thresholds)(
-      projects: Seq[ProjectSummary],
-      total: Metrics
-  ): String =
+  private[scoverage] final def render(layout: Layout)(projects: Seq[ProjectSummary], total: Summary): String =
     layout match {
       case Layout.Auto =>
-        if (projects.length == 1) render(statements, branches, projects.head)
-        else render(statements, branches, projects, total)
-      case Layout.Multi => render(statements, branches, projects, total)
-      case Layout.Total => render(statements, branches, total)
+        if (projects.length == 1) render(projects.head)
+        else render(projects, total)
+      case Layout.Multi => render(projects, total)
+      case Layout.Total => render(total)
     }
 
-  def render(statements: Thresholds, branches: Thresholds, projects: Seq[ProjectSummary], total: Metrics): String
+  def render(projects: Seq[ProjectSummary], total: Summary): String
 
-  def render(statements: Thresholds, branches: Thresholds, project: ProjectSummary): String
+  def render(project: ProjectSummary): String
 
-  def render(statements: Thresholds, branches: Thresholds, total: Metrics): String
+  def render(total: Summary): String
 
   def filename: String
 }
@@ -30,9 +27,7 @@ object Format {
   case object GitHubFlavoredMarkdown extends Format {
     val name = "GitHub flavored markdown"
 
-    def render(statements: Thresholds, branches: Thresholds, projects: Seq[ProjectSummary], total: Metrics): String = {
-      val statementRender = render(statements)(_, _)
-      val branchRender = render(branches)(_, _)
+    def render(projects: Seq[ProjectSummary], total: Summary): String =
       <table>
         <thead>
           <tr>
@@ -47,16 +42,16 @@ object Format {
         <tbody>
           {
         projects map { project =>
-          import project.metrics as m
+          import project.summary.metrics as m
           <tr>
             <td>{project.name}</td><td>{project.id}</td>
             <td align="right">{m.statements}</td>
             <td align="right">{m.invokedStatements}</td>
             <td align="right">{m.ignoredStatements}</td>
-            <td align="right">{statementRender(m.invokedStatements, m.statements)}</td>
+            <td align="right">{renderRate(project.summary.statements)(m.invokedStatements, m.statements)}</td>
             <td align="right">{m.branches}</td>
             <td align="right">{m.invokedBranches}</td>
-            <td align="right">{branchRender(m.invokedBranches, m.branches)}</td>
+            <td align="right">{renderRate(project.summary.branches)(m.invokedBranches, m.branches)}</td>
           </tr>
         }
       }
@@ -64,45 +59,46 @@ object Format {
         <tfoot align="right">
           <tr>
             <td colspan="2"></td>
-            <td align="right">{total.statements}</td>
-            <td align="right">{total.invokedStatements}</td>
-            <td align="right">{total.ignoredStatements}</td>
-            <td align="right">{statementRender(total.invokedStatements, total.statements)}</td>
-            <td align="right">{total.branches}</td>
-            <td align="right">{total.invokedBranches}</td>
-            <td align="right">{branchRender(total.invokedBranches, total.branches)}</td>
+            <td align="right">{total.metrics.statements}</td>
+            <td align="right">{total.metrics.invokedStatements}</td>
+            <td align="right">{total.metrics.ignoredStatements}</td>
+            <td align="right">
+              {renderRate(total.statements)(total.metrics.invokedStatements, total.metrics.statements)}
+            </td>
+            <td align="right">{total.metrics.branches}</td>
+            <td align="right">{total.metrics.invokedBranches}</td>
+            <td align="right">
+              {renderRate(total.branches)(total.metrics.invokedBranches, total.metrics.branches)}
+            </td>
             </tr>
           </tfoot>
       </table>.toString()
-    }
 
-    def render(statements: Thresholds, branches: Thresholds, project: ProjectSummary): String =
+    def render(project: ProjectSummary): String =
       <table>
         <thead>
           <tr><th rowspan="2">Project</th><th>Name</th><td align="center">{project.name}</td></tr>
           <tr><th>ID</th><td align="center">{project.id}</td></tr>
         </thead>
-        {renderMetricsBody(statements, branches, project.metrics)}
+        {renderMetricsBody(project.summary)}
       </table>.toString()
 
-    def render(statements: Thresholds, branches: Thresholds, metrics: Metrics): String =
-      <table>{renderMetricsBody(statements, branches, metrics)}</table>.toString()
+    def render(total: Summary): String = <table>{renderMetricsBody(total)}</table>.toString()
 
-    private def renderMetricsBody(statements: Thresholds, branches: Thresholds, metrics: Metrics): Elem = {
-      val statementRender = render(statements)(_, _)
-      val branchRender = render(branches)(_, _)
+    private def renderMetricsBody(summary: Summary): Elem = {
+      import summary.metrics as m
       <tbody>
-        <tr><th rowspan="4">Statements</th><th>Total</th><td align="right">{metrics.statements}</td></tr>
-        <tr><th>Invoked</th><td align="right">{metrics.invokedStatements}</td></tr>
-        <tr><th>Ignored</th><td align="right">{metrics.ignoredStatements}</td></tr>
-        <tr><th>Rate</th><td align="right">{statementRender(metrics.invokedStatements, metrics.statements)}</td></tr>
-        <tr><th rowspan="3">Branches</th><th>Total</th><td align="right">{metrics.branches}</td></tr>
-        <tr><th>Invoked</th><td align="right">{metrics.invokedBranches}</td></tr>
-        <tr><th>Rate</th><td align="right">{branchRender(metrics.invokedBranches, metrics.branches)}</td></tr>
+        <tr><th rowspan="4">Statements</th><th>Total</th><td align="right">{m.statements}</td></tr>
+        <tr><th>Invoked</th><td align="right">{m.invokedStatements}</td></tr>
+        <tr><th>Ignored</th><td align="right">{m.ignoredStatements}</td></tr>
+        <tr><th>Rate</th><td align="right">{renderRate(summary.statements)(m.invokedStatements, m.statements)}</td></tr>
+        <tr><th rowspan="3">Branches</th><th>Total</th><td align="right">{m.branches}</td></tr>
+        <tr><th>Invoked</th><td align="right">{m.invokedBranches}</td></tr>
+        <tr><th>Rate</th><td align="right">{renderRate(summary.branches)(m.invokedBranches, m.branches)}</td></tr>
       </tbody>
     }
 
-    private def render(thresholds: Thresholds)(invoked: Int, total: Int): String =
+    private def renderRate(thresholds: Thresholds)(invoked: Int, total: Int): String =
       if (total == 0) "$\\textemdash$"
       else {
         val rate = invoked.toFloat / total * 100

--- a/plugin/src/main/scala/h8io/sbt/scoverage/ProjectSummary.scala
+++ b/plugin/src/main/scala/h8io/sbt/scoverage/ProjectSummary.scala
@@ -3,9 +3,14 @@ package h8io.sbt.scoverage
 import sbt.ProjectRef
 import scoverage.domain.Coverage
 
-final case class ProjectSummary(id: String, name: String, metrics: Metrics)
+final case class ProjectSummary(id: String, name: String, summary: Summary)
 
 object ProjectSummary {
-  def apply(ref: ProjectRef, name: String, coverage: Coverage): ProjectSummary =
-    ProjectSummary(ref.project, name, Metrics(coverage))
+  def apply(
+      ref: ProjectRef,
+      name: String,
+      coverage: Coverage,
+      statements: Thresholds,
+      branches: Thresholds
+  ): ProjectSummary = ProjectSummary(ref.project, name, Summary(Metrics(coverage), statements, branches))
 }

--- a/plugin/src/main/scala/h8io/sbt/scoverage/ScoverageProjectSummaryPlugin.scala
+++ b/plugin/src/main/scala/h8io/sbt/scoverage/ScoverageProjectSummaryPlugin.scala
@@ -1,5 +1,6 @@
 package h8io.sbt.scoverage
 
+import h8io.sbt.scoverage.ScoverageSummaryPlugin.autoImport.*
 import sbt.*
 import sbt.Keys.{baseDirectory, crossTarget, name, thisProjectRef}
 import sbt.plugins.JvmPlugin
@@ -14,6 +15,20 @@ object ScoverageProjectSummaryPlugin extends AutoPlugin {
 
   override def requires: Plugins = JvmPlugin
 
+  // Threshold defaults live in the global scope rather than in project settings, so that they are the last link of the
+  // `project -> ThisBuild -> Global` delegation chain: a module which defines none of them still resolves a value,
+  // while `ThisBuild / ...` and `someModule / ...` both take precedence. Defining them per project would instead give
+  // every module an explicit value of its own and silently mask any `ThisBuild` override.
+  // They belong to this plugin, which is always active, because `summary` below reads them in every module regardless
+  // of where ScoverageSummaryPlugin is enabled.
+  override def globalSettings: Seq[Def.Setting[?]] =
+    Seq(
+      coverageSummaryStmtLowThreshold := 50,
+      coverageSummaryStmtHighThreshold := 75,
+      coverageSummaryBranchLowThreshold := 50,
+      coverageSummaryBranchHighThreshold := 75
+    )
+
   override def projectSettings: Seq[Def.Setting[?]] =
     Seq(
       summary := {
@@ -21,7 +36,15 @@ object ScoverageProjectSummaryPlugin extends AutoPlugin {
         if (dataDir.exists()) {
           val coverage = Serializer.deserialize(Serializer.coverageFile(dataDir), baseDirectory.value)
           coverage(IOUtils.invoked(IOUtils.findMeasurementFiles(dataDir).toIndexedSeq))
-          Some(ProjectSummary(thisProjectRef.value, name.value, coverage))
+          Some(
+            ProjectSummary(
+              thisProjectRef.value,
+              name.value,
+              coverage,
+              Thresholds(coverageSummaryStmtLowThreshold.value, coverageSummaryStmtHighThreshold.value),
+              Thresholds(coverageSummaryBranchLowThreshold.value, coverageSummaryBranchHighThreshold.value)
+            )
+          )
         } else None
       }
     )

--- a/plugin/src/main/scala/h8io/sbt/scoverage/ScoverageSummaryPlugin.scala
+++ b/plugin/src/main/scala/h8io/sbt/scoverage/ScoverageSummaryPlugin.scala
@@ -25,28 +25,28 @@ object ScoverageSummaryPlugin extends AutoPlugin {
     Seq(
       coverageSummary / aggregate := false,
       coverageSummaryFormat := Set(Format.GitHubFlavoredMarkdown),
-      coverageSummaryStmtLowThreshold := 50,
-      coverageSummaryStmtHighThreshold := 75,
-      coverageSummaryBranchLowThreshold := 50,
-      coverageSummaryBranchHighThreshold := 75,
       coverageSummaryLayout := Layout.Auto,
       coverageSummary := {
-        val statements = Thresholds(coverageSummaryStmtLowThreshold.value, coverageSummaryStmtHighThreshold.value)
-        val branches = Thresholds(coverageSummaryBranchLowThreshold.value, coverageSummaryBranchHighThreshold.value)
-        val errors = validateThresholds("Stmt", statements).toSeq ++ validateThresholds("Branch", branches)
-        if (errors.nonEmpty) throw new MessageOnlyException(errors.mkString("\n"))
         val projects = ScoverageProjectSummaryPlugin.summary
           .all(ScopeFilter(inAggregates(ThisProject, includeRoot = true)))
           .value
           .flatten
+        val scope = thisProjectRef.value.project
+        // The total row is judged by the thresholds of the aggregating project, which are not necessarily those of any
+        // single module.
+        val statements = Thresholds(coverageSummaryStmtLowThreshold.value, coverageSummaryStmtHighThreshold.value)
+        val branches = Thresholds(coverageSummaryBranchLowThreshold.value, coverageSummaryBranchHighThreshold.value)
         total(projects) match {
-          case Some(total) =>
+          case Some(metrics) =>
+            val total = Summary(metrics, statements, branches)
+            val errors = validate(projects, scope, total)
+            if (errors.nonEmpty) throw new MessageOnlyException(errors.mkString("\n"))
             for {
               format <- coverageSummaryFormat.value
-              render = format.render(coverageSummaryLayout.value, statements, branches)(_, _)
+              render = format.render(coverageSummaryLayout.value)(_, _)
               filename = crossTarget.value / "scoverage-summary" / format.filename
               summary =
-                "## " + name.value + " (" + thisProjectRef.value.project + ")\n### Scala " + scalaBinaryVersion.value +
+                "## " + name.value + " (" + scope + ")\n### Scala " + scalaBinaryVersion.value +
                   (if (sbtPlugin.value) ", SBT " + (pluginCrossBuild / sbtBinaryVersion).value else "") + "\n" +
                   render(projects.sortBy(_.name), total) + "\n\n"
             } {
@@ -64,7 +64,18 @@ object ScoverageSummaryPlugin extends AutoPlugin {
 
   // Visible for testing
   private[scoverage] def total(projects: Seq[ProjectSummary]): Option[Metrics] =
-    projects.iterator.map(_.metrics).reduceOption(_ + _)
+    projects.iterator.map(_.summary.metrics).reduceOption(_ + _)
+
+  // Visible for testing
+  // Every module resolves its own thresholds, so all of them are validated and every violation is reported at once.
+  // `totalScope` labels the thresholds of the aggregating project; when that project is aggregated into the report as
+  // well, the two labels coincide and the duplicate message collapses.
+  private[scoverage] def validate(projects: Seq[ProjectSummary], totalScope: String, total: Summary): Seq[String] =
+    ((projects.map(project => project.id -> project.summary) :+ (totalScope -> total)) flatMap {
+      case (scope, summary) =>
+        (validateThresholds("Stmt", summary.statements).toSeq ++ validateThresholds("Branch", summary.branches))
+          .map(message => s"[$scope] $message")
+    }).distinct
 
   // Visible for testing
   // Coverage rates are always within [0, 100], so a threshold outside that range makes a color unreachable,

--- a/plugin/src/main/scala/h8io/sbt/scoverage/Summary.scala
+++ b/plugin/src/main/scala/h8io/sbt/scoverage/Summary.scala
@@ -1,0 +1,7 @@
+package h8io.sbt.scoverage
+
+/** Coverage of a single scope together with the thresholds it is judged by. Thresholds travel with the metrics rather
+  * than being passed to a format separately, because every module resolves its own values and a table may therefore mix
+  * several sets of them.
+  */
+final case class Summary(metrics: Metrics, statements: Thresholds, branches: Thresholds)

--- a/plugin/src/test/scala/h8io/sbt/scoverage/FormatTest.scala
+++ b/plugin/src/test/scala/h8io/sbt/scoverage/FormatTest.scala
@@ -8,77 +8,72 @@ class FormatTest extends AnyFlatSpec with Matchers with MockFactory {
   private val statements = Thresholds(0.3f, 0.8f)
   private val branches = Thresholds(0.1f, 0.5f)
 
-  private val project = ProjectSummary("root", "single", Metrics(12, 7, 1, 10, 5))
+  private def summary(metrics: Metrics) = Summary(metrics, statements, branches)
+
+  private val project = ProjectSummary("root", "single", summary(Metrics(12, 7, 1, 10, 5)))
   private val projects = Seq(
-    ProjectSummary("project1", "project-1", Metrics(23, 21, 3, 11, 10)),
-    ProjectSummary("project2", "project-2", Metrics(17, 11, 0, 19, 13))
+    ProjectSummary("project1", "project-1", summary(Metrics(23, 21, 3, 11, 10))),
+    ProjectSummary("project2", "project-2", summary(Metrics(17, 11, 0, 19, 13)))
   )
-  private val metrics = projects.iterator.map(_.metrics).reduce(_ + _)
+  private val total = summary(projects.iterator.map(_.summary.metrics).reduce(_ + _))
 
   "render" should s"invoke the correct method for a single project when layout is ${Layout.Auto}" in {
     val format = mock[Format]
     val result = "single project summary with auto layout"
-    (format
-      .render(_: Thresholds, _: Thresholds, _: ProjectSummary))
-      .expects(statements, branches, project)
-      .returns(result)
-    format.render(Layout.Auto, statements, branches)(project :: Nil, project.metrics) shouldEqual result
+    (format.render(_: ProjectSummary)).expects(project).returns(result)
+    format.render(Layout.Auto)(project :: Nil, project.summary) shouldEqual result
   }
 
   it should s"invoke the correct method for multiple projects when layout is ${Layout.Auto}" in {
     val format = mock[Format]
     val result = "multiproject summary with auto layout"
-    (format
-      .render(_: Thresholds, _: Thresholds, _: Seq[ProjectSummary], _: Metrics))
-      .expects(statements, branches, projects, metrics)
-      .returns(result)
-    format.render(Layout.Auto, statements, branches)(projects, metrics) shouldEqual result
+    (format.render(_: Seq[ProjectSummary], _: Summary)).expects(projects, total).returns(result)
+    format.render(Layout.Auto)(projects, total) shouldEqual result
   }
 
   it should s"invoke the correct method for a single project when layout is ${Layout.Multi}" in {
     val format = mock[Format]
     val result = s"single project summary with layout ${Layout.Multi}"
-    (format
-      .render(_: Thresholds, _: Thresholds, _: Seq[ProjectSummary], _: Metrics))
-      .expects(statements, branches, project :: Nil, project.metrics)
-      .returns(result)
-    format.render(Layout.Multi, statements, branches)(project :: Nil, project.metrics) shouldEqual result
+    (format.render(_: Seq[ProjectSummary], _: Summary)).expects(project :: Nil, project.summary).returns(result)
+    format.render(Layout.Multi)(project :: Nil, project.summary) shouldEqual result
   }
 
   it should s"invoke the correct method for multiple projects when layout is ${Layout.Multi}" in {
     val format = mock[Format]
     val result = s"multiproject summary with layout ${Layout.Multi}"
-    (format
-      .render(_: Thresholds, _: Thresholds, _: Seq[ProjectSummary], _: Metrics))
-      .expects(statements, branches, projects, metrics)
-      .returns(result)
-    format.render(Layout.Multi, statements, branches)(projects, metrics) shouldEqual result
+    (format.render(_: Seq[ProjectSummary], _: Summary)).expects(projects, total).returns(result)
+    format.render(Layout.Multi)(projects, total) shouldEqual result
   }
 
   it should s"invoke the correct method for a single project when layout is ${Layout.Total}" in {
     val format = mock[Format]
     val result = s"single project summary with layout ${Layout.Total}"
-    (format
-      .render(_: Thresholds, _: Thresholds, _: Metrics))
-      .expects(statements, branches, project.metrics)
-      .returns(result)
-    format.render(Layout.Total, statements, branches)(project :: Nil, project.metrics) shouldEqual result
+    (format.render(_: Summary)).expects(project.summary).returns(result)
+    format.render(Layout.Total)(project :: Nil, project.summary) shouldEqual result
   }
 
   it should s"invoke the correct method for multiple projects when layout is ${Layout.Total}" in {
     val format = mock[Format]
     val result = s"multiproject summary with layout ${Layout.Total}"
-    (format
-      .render(_: Thresholds, _: Thresholds, _: Metrics))
-      .expects(statements, branches, metrics)
-      .returns(result)
-    format.render(Layout.Total, statements, branches)(projects, metrics) shouldEqual result
+    (format.render(_: Summary)).expects(total).returns(result)
+    format.render(Layout.Total)(projects, total) shouldEqual result
   }
 
   s"${Format.GitHubFlavoredMarkdown.name}" should "color statements and branches by their own thresholds" in {
-    val equalRates = Metrics(10, 5, 0, 10, 5)
-    val rendered = Format.GitHubFlavoredMarkdown.render(Thresholds(60, 80), Thresholds(20, 40), equalRates)
+    val equalRates = Summary(Metrics(10, 5, 0, 10, 5), Thresholds(60, 80), Thresholds(20, 40))
+    val rendered = Format.GitHubFlavoredMarkdown.render(equalRates)
     rendered should include("\\color{#f00}50.00")
     rendered should include("\\color{#0f0}50.00")
+  }
+
+  it should "color every project by its own thresholds" in {
+    val metrics = Metrics(10, 5, 0, 10, 5)
+    val strict = ProjectSummary("strict", "strict", Summary(metrics, Thresholds(60, 80), Thresholds(60, 80)))
+    val lenient = ProjectSummary("lenient", "lenient", Summary(metrics, Thresholds(20, 40), Thresholds(20, 40)))
+    val rendered = Format.GitHubFlavoredMarkdown
+      .render(Seq(strict, lenient), Summary(metrics + metrics, Thresholds(40, 60), Thresholds(40, 60)))
+    rendered should include("\\color{#f00}50.00")
+    rendered should include("\\color{#0f0}50.00")
+    rendered should include("\\color{#ff0}50.00")
   }
 }

--- a/plugin/src/test/scala/h8io/sbt/scoverage/ScoverageSummaryPluginTest.scala
+++ b/plugin/src/test/scala/h8io/sbt/scoverage/ScoverageSummaryPluginTest.scala
@@ -5,15 +5,21 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 class ScoverageSummaryPluginTest extends AnyFlatSpec with Matchers with OptionValues {
+  private val valid = Thresholds(50, 75)
+  private val invalid = Thresholds(75, 50)
+
+  private def project(id: String, statements: Thresholds = valid, branches: Thresholds = valid) =
+    ProjectSummary(id, id, Summary(Metrics(3, 2, 1, 5, 4), statements, branches))
+
   "total" should "return None for an empty sequence" in {
     ScoverageSummaryPlugin.total(Nil) shouldBe None
   }
 
   it should "return a summary metric for a non-empty sequence" in {
     ScoverageSummaryPlugin.total(
-      ProjectSummary("project1", "project-1", Metrics(3, 2, 1, 5, 4)) ::
-        ProjectSummary("project2", "project-2", Metrics(7, 5, 3, 9, 7)) ::
-        ProjectSummary("project3", "project-3", Metrics(9, 7, 5, 13, 11)) ::
+      ProjectSummary("project1", "project-1", Summary(Metrics(3, 2, 1, 5, 4), valid, valid)) ::
+        ProjectSummary("project2", "project-2", Summary(Metrics(7, 5, 3, 9, 7), valid, valid)) ::
+        ProjectSummary("project3", "project-3", Summary(Metrics(9, 7, 5, 13, 11), valid, valid)) ::
         Nil
     ) shouldBe Some(Metrics(19, 14, 9, 27, 22))
   }
@@ -50,5 +56,39 @@ class ScoverageSummaryPluginTest extends AnyFlatSpec with Matchers with OptionVa
     ScoverageSummaryPlugin.validateThresholds("Branch", Thresholds(75, 50)).value should (
       include("coverageSummaryBranchLowThreshold") and include("coverageSummaryBranchHighThreshold")
     )
+  }
+
+  private val total = Summary(Metrics(3, 2, 1, 5, 4), valid, valid)
+
+  "validate" should "accept modules which all resolve consistent thresholds" in {
+    ScoverageSummaryPlugin.validate(Seq(project("a"), project("b")), "root", total) shouldBe empty
+  }
+
+  it should "report every offending module rather than stopping at the first one" in {
+    val projects = Seq(project("a", statements = invalid), project("b"), project("c", branches = invalid))
+    val errors = ScoverageSummaryPlugin.validate(projects, "root", total)
+    errors should have size 2
+    exactly(1, errors) should include("[a]")
+    exactly(1, errors) should include("[c]")
+  }
+
+  it should "report both metrics of the same module" in {
+    ScoverageSummaryPlugin.validate(
+      Seq(project("a", statements = invalid, branches = invalid)),
+      "root",
+      total
+    ) should have size 2
+  }
+
+  it should "report the thresholds of the aggregating project" in {
+    val errors =
+      ScoverageSummaryPlugin.validate(Nil, "root", Summary(Metrics(3, 2, 1, 5, 4), invalid, valid))
+    errors should have size 1
+    errors.head should include("[root]")
+  }
+
+  it should "not report the aggregating project twice when it is aggregated into itself" in {
+    val root = project("root", statements = invalid)
+    ScoverageSummaryPlugin.validate(Seq(root), "root", root.summary) should have size 1
   }
 }


### PR DESCRIPTION
## Summary

Thresholds were read once, in the aggregating project, and applied to every row of the report. A build whose modules are held to different standards — a well covered core next to an examples module nobody intends to test — had to calibrate the whole report for its weakest member.

Each module now resolves its own thresholds, and the report may mix several sets of them.

```sbt
ThisBuild / coverageSummaryStmtLowThreshold := 60

lazy val core = project.settings(coverageSummaryStmtLowThreshold := 90)
lazy val examples = project.settings(coverageSummaryStmtLowThreshold := 0)
```

### No optional setting layer

The requested semantics — per-module value when defined, global otherwise — is what SBT's `project -> ThisBuild -> Global` delegation already does. The only change needed was moving the defaults out of project settings and into the global scope. Nothing is wrapped in `Option`, and nothing has to be resolved by hand.

Leaving the defaults in project settings would have been actively wrong, not merely redundant: every module carrying the plugin would then hold an explicit value of its own, and a `ThisBuild / coverageSummaryStmtLowThreshold` override would be silently masked by it.

The defaults belong to `ScoverageProjectSummaryPlugin` rather than to `ScoverageSummaryPlugin`. The former is `allRequirements` and therefore always active, and it is the one whose task reads the keys in every module — including builds where `ScoverageSummaryPlugin` is not enabled anywhere, which would otherwise fail to load on an undefined setting.

### Thresholds travel with the data

The aggregator could have harvested thresholds with a second `ScopeFilter` and zipped them with the summaries by position. The two sequences do line up today, but the coupling is invisible and would break silently — colors would simply land on the wrong rows.

Instead the per-module task that already runs everywhere reads its own thresholds and attaches them to the `ProjectSummary` it returns. There is no zip left to get wrong. Consequently a `Format` no longer receives thresholds as parameters at all; they arrive with the metrics as `Summary`, which makes the rendering API smaller than it was before.

### Total row

The total is judged by the thresholds of the aggregating project. Its color is deliberately not derived from the rows: modules that are all green can still add up to a yellow total, because the total is a different number measured against a different pair. This is documented in the README.

All modules are validated, and a build that is inconsistent in several of them reports every violation at once, each prefixed with the module id.

## Breaking change

`Format` implementations outside this repository will not compile. Same major release as the threshold split that preceded it.

## Test plan

- 24 unit tests pass on both matrix rows; `scalafmtSbtCheck` and `scalafmtCheckAll` clean
- new tests cover per-project coloring in one table, and validation reporting every offending module, both metrics of one module, the aggregating project's own thresholds, and the deduplication when the aggregator is aggregated into itself
- verified end to end on a three-module scratch build against a locally published version, all rates identical at 0.00% so that only thresholds could differ:

  | row | statements | branches |
  |---|---|---|
  | `a` — own project-scoped values | green (0/0) | red (90/95) |
  | `b` — nothing set | red, **Global** default (50/75) | green, **ThisBuild** (0/0) |
  | total — aggregator's values | yellow (0/30) | green (0/0) |

  which exercises all three levels of the delegation chain in a single table.
- the same stand confirmed that the keys can be scoped to modules where `ScoverageSummaryPlugin` is not enabled, and that a module whose thresholds are inconsistent is named in the error

🤖 Generated with [Claude Code](https://claude.com/claude-code)