### PR TITLE
Fail on insufficient coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,42 @@ is therefore not derivable from the colors of the rows above it: modules that ar
 all green can still add up to a yellow total, since the total is a different
 number measured against a different pair of thresholds.
 
+### Failing on insufficient coverage
+
+* coverageSummaryStmtMinimum, coverageSummaryBranchMinimum - type is Option[Float],
+  the coverage rate below which `coverageSummaryCheck` fails. `None`, the default,
+  means the low threshold of the same metric in the same module, so that everything
+  which fails the check is also rendered in red.
+
+`coverageSummaryCheck` generates the report exactly as `coverageSummary` does and
+only then fails, so the report reaches its destination either way. It is a separate
+task, so adding it to a build is an explicit decision and nothing starts failing on
+an upgrade.
+
+```sbt
+// core has to stay well covered
+lazy val core = project.settings(coverageSummaryStmtMinimum := Some(90))
+
+// examples are not expected to be covered at all
+lazy val examples = project.settings(
+  coverageSummaryStmtMinimum := Some(0),
+  coverageSummaryBranchMinimum := Some(0)
+)
+```
+
+Minimums are resolved per module exactly like thresholds, and are checked with a
+strict comparison: a rate equal to the minimum passes, and `Some(100)` is therefore
+reachable by fully covered code. A metric with nothing to cover has no rate and
+never fails, the same reason its cell is rendered as a dash.
+
+Every module and every metric is checked, and all violations are reported at once.
+The total is checked too, and it is not implied by the modules: a module exempted
+with a minimum of its own can drag the total below the minimum of the aggregating
+project while every module still passes.
+
+A minimum above the low threshold of its metric is allowed but produces a warning,
+because the offending cell is then rendered in yellow or green while the build fails.
+
 ## Usage
 
 ### plugins.sbt

--- a/plugin/src/main/scala/h8io/sbt/scoverage/Format.scala
+++ b/plugin/src/main/scala/h8io/sbt/scoverage/Format.scala
@@ -48,10 +48,10 @@ object Format {
             <td align="right">{m.statements}</td>
             <td align="right">{m.invokedStatements}</td>
             <td align="right">{m.ignoredStatements}</td>
-            <td align="right">{renderRate(project.summary.statements)(m.invokedStatements, m.statements)}</td>
+            <td align="right">{renderRate(project.summary.statements)(m.statementRate)}</td>
             <td align="right">{m.branches}</td>
             <td align="right">{m.invokedBranches}</td>
-            <td align="right">{renderRate(project.summary.branches)(m.invokedBranches, m.branches)}</td>
+            <td align="right">{renderRate(project.summary.branches)(m.branchRate)}</td>
           </tr>
         }
       }
@@ -62,14 +62,10 @@ object Format {
             <td align="right">{total.metrics.statements}</td>
             <td align="right">{total.metrics.invokedStatements}</td>
             <td align="right">{total.metrics.ignoredStatements}</td>
-            <td align="right">
-              {renderRate(total.statements)(total.metrics.invokedStatements, total.metrics.statements)}
-            </td>
+            <td align="right">{renderRate(total.statements)(total.metrics.statementRate)}</td>
             <td align="right">{total.metrics.branches}</td>
             <td align="right">{total.metrics.invokedBranches}</td>
-            <td align="right">
-              {renderRate(total.branches)(total.metrics.invokedBranches, total.metrics.branches)}
-            </td>
+            <td align="right">{renderRate(total.branches)(total.metrics.branchRate)}</td>
             </tr>
           </tfoot>
       </table>.toString()
@@ -91,22 +87,22 @@ object Format {
         <tr><th rowspan="4">Statements</th><th>Total</th><td align="right">{m.statements}</td></tr>
         <tr><th>Invoked</th><td align="right">{m.invokedStatements}</td></tr>
         <tr><th>Ignored</th><td align="right">{m.ignoredStatements}</td></tr>
-        <tr><th>Rate</th><td align="right">{renderRate(summary.statements)(m.invokedStatements, m.statements)}</td></tr>
+        <tr><th>Rate</th><td align="right">{renderRate(summary.statements)(m.statementRate)}</td></tr>
         <tr><th rowspan="3">Branches</th><th>Total</th><td align="right">{m.branches}</td></tr>
         <tr><th>Invoked</th><td align="right">{m.invokedBranches}</td></tr>
-        <tr><th>Rate</th><td align="right">{renderRate(summary.branches)(m.invokedBranches, m.branches)}</td></tr>
+        <tr><th>Rate</th><td align="right">{renderRate(summary.branches)(m.branchRate)}</td></tr>
       </tbody>
     }
 
-    private def renderRate(thresholds: Thresholds)(invoked: Int, total: Int): String =
-      if (total == 0) "$\\textemdash$"
-      else {
-        val rate = invoked.toFloat / total * 100
-        val color =
-          if (rate < thresholds.low) "#f00"
-          else if (rate < thresholds.high) "#ff0"
-          else "#0f0"
-        f"$$\\color{$color}$rate%2.02f\\%%$$"
+    private def renderRate(thresholds: Thresholds)(rate: Option[Float]): String =
+      rate match {
+        case None => "$\\textemdash$"
+        case Some(rate) =>
+          val color =
+            if (rate < thresholds.low) "#f00"
+            else if (rate < thresholds.high) "#ff0"
+            else "#0f0"
+          f"$$\\color{$color}$rate%2.02f\\%%$$"
       }
 
     override val filename: String = "gfm.md"

--- a/plugin/src/main/scala/h8io/sbt/scoverage/Metrics.scala
+++ b/plugin/src/main/scala/h8io/sbt/scoverage/Metrics.scala
@@ -17,9 +17,20 @@ final case class Metrics(
       branches + that.branches,
       invokedBranches + that.invokedBranches
     )
+
+  /** Percentages of the covered code, `None` when there is nothing to cover. Both the report and the coverage check
+    * read the rates from here, so that a cell rendered in red and a failing module can never disagree.
+    */
+  def statementRate: Option[Float] = Metrics.rate(invokedStatements, statements)
+
+  def branchRate: Option[Float] = Metrics.rate(invokedBranches, branches)
 }
 
 object Metrics {
+  // Dividing equal Ints is exact in IEEE-754, so full coverage yields exactly 100 and a minimum of 100 is reachable.
+  private def rate(invoked: Int, total: Int): Option[Float] =
+    if (total == 0) None else Some(invoked.toFloat / total * 100)
+
   def apply(coverage: Coverage): Metrics =
     Metrics(
       coverage.statementCount,

--- a/plugin/src/main/scala/h8io/sbt/scoverage/Minimum.scala
+++ b/plugin/src/main/scala/h8io/sbt/scoverage/Minimum.scala
@@ -1,0 +1,7 @@
+package h8io.sbt.scoverage
+
+/** Coverage rates below which `coverageSummaryCheck` fails. Kept apart from [[Thresholds]] because a threshold only
+  * picks a color while a minimum blocks the build, even though by default a minimum equals the low threshold of its
+  * metric and the two therefore agree.
+  */
+final case class Minimum(statements: Float, branches: Float)

--- a/plugin/src/main/scala/h8io/sbt/scoverage/ProjectSummary.scala
+++ b/plugin/src/main/scala/h8io/sbt/scoverage/ProjectSummary.scala
@@ -1,16 +1,10 @@
 package h8io.sbt.scoverage
 
 import sbt.ProjectRef
-import scoverage.domain.Coverage
 
 final case class ProjectSummary(id: String, name: String, summary: Summary)
 
 object ProjectSummary {
-  def apply(
-      ref: ProjectRef,
-      name: String,
-      coverage: Coverage,
-      statements: Thresholds,
-      branches: Thresholds
-  ): ProjectSummary = ProjectSummary(ref.project, name, Summary(Metrics(coverage), statements, branches))
+  def apply(ref: ProjectRef, name: String, summary: Summary): ProjectSummary =
+    ProjectSummary(ref.project, name, summary)
 }

--- a/plugin/src/main/scala/h8io/sbt/scoverage/ScoverageProjectSummaryPlugin.scala
+++ b/plugin/src/main/scala/h8io/sbt/scoverage/ScoverageProjectSummaryPlugin.scala
@@ -26,25 +26,34 @@ object ScoverageProjectSummaryPlugin extends AutoPlugin {
       coverageSummaryStmtLowThreshold := 50,
       coverageSummaryStmtHighThreshold := 75,
       coverageSummaryBranchLowThreshold := 50,
-      coverageSummaryBranchHighThreshold := 75
+      coverageSummaryBranchHighThreshold := 75,
+      coverageSummaryStmtMinimum := None,
+      coverageSummaryBranchMinimum := None
     )
+
+  // A minimum left undefined follows the low threshold of its own metric. That fallback cannot be expressed as a
+  // setting default: defined globally it would resolve the threshold globally too and miss per-module overrides, and
+  // `Def.derive` would place it in the project scope, where it outranks and thereby masks `ThisBuild / ...`. Resolving
+  // it here instead keeps both, because every module evaluates this in its own scope.
+  private[scoverage] lazy val summarize: Def.Initialize[Metrics => Summary] = Def.setting {
+    val statements = Thresholds(coverageSummaryStmtLowThreshold.value, coverageSummaryStmtHighThreshold.value)
+    val branches = Thresholds(coverageSummaryBranchLowThreshold.value, coverageSummaryBranchHighThreshold.value)
+    val minimum = Minimum(
+      coverageSummaryStmtMinimum.value getOrElse statements.low,
+      coverageSummaryBranchMinimum.value getOrElse branches.low
+    )
+    metrics => Summary(metrics, statements, branches, minimum)
+  }
 
   override def projectSettings: Seq[Def.Setting[?]] =
     Seq(
       summary := {
         val dataDir = crossTarget.value / Constants.DataDir
+        val toSummary = summarize.value
         if (dataDir.exists()) {
           val coverage = Serializer.deserialize(Serializer.coverageFile(dataDir), baseDirectory.value)
           coverage(IOUtils.invoked(IOUtils.findMeasurementFiles(dataDir).toIndexedSeq))
-          Some(
-            ProjectSummary(
-              thisProjectRef.value,
-              name.value,
-              coverage,
-              Thresholds(coverageSummaryStmtLowThreshold.value, coverageSummaryStmtHighThreshold.value),
-              Thresholds(coverageSummaryBranchLowThreshold.value, coverageSummaryBranchHighThreshold.value)
-            )
-          )
+          Some(ProjectSummary(thisProjectRef.value, name.value, toSummary(Metrics(coverage))))
         } else None
       }
     )

--- a/plugin/src/main/scala/h8io/sbt/scoverage/ScoverageSummaryPlugin.scala
+++ b/plugin/src/main/scala/h8io/sbt/scoverage/ScoverageSummaryPlugin.scala
@@ -7,12 +7,17 @@ import scoverage.ScoverageSbtPlugin
 
 object ScoverageSummaryPlugin extends AutoPlugin {
   object autoImport {
-    @transient val coverageSummary = taskKey[Unit]("Generate scoverage summary")
+    @transient val coverageSummary = taskKey[Seq[ProjectSummary]]("Generate scoverage summary")
+    @transient val coverageSummaryCheck = taskKey[Unit]("Generate scoverage summary and fail below the minimums")
     val coverageSummaryFormat = settingKey[Set[Format]]("Summary format")
     val coverageSummaryStmtLowThreshold = settingKey[Float]("Statement coverage low threshold (red)")
     val coverageSummaryStmtHighThreshold = settingKey[Float]("Statement coverage high threshold (green)")
     val coverageSummaryBranchLowThreshold = settingKey[Float]("Branch coverage low threshold (red)")
     val coverageSummaryBranchHighThreshold = settingKey[Float]("Branch coverage high threshold (green)")
+    val coverageSummaryStmtMinimum =
+      settingKey[Option[Float]]("Statement coverage minimum, defaults to the low threshold")
+    val coverageSummaryBranchMinimum =
+      settingKey[Option[Float]]("Branch coverage minimum, defaults to the low threshold")
     val coverageSummaryLayout = settingKey[Layout]("Summary layout")
   }
   import autoImport.*
@@ -24,6 +29,7 @@ object ScoverageSummaryPlugin extends AutoPlugin {
   override def projectSettings: Seq[Def.Setting[?]] =
     Seq(
       coverageSummary / aggregate := false,
+      coverageSummaryCheck / aggregate := false,
       coverageSummaryFormat := Set(Format.GitHubFlavoredMarkdown),
       coverageSummaryLayout := Layout.Auto,
       coverageSummary := {
@@ -32,13 +38,12 @@ object ScoverageSummaryPlugin extends AutoPlugin {
           .value
           .flatten
         val scope = thisProjectRef.value.project
-        // The total row is judged by the thresholds of the aggregating project, which are not necessarily those of any
+        // The total row is judged by the values of the aggregating project, which are not necessarily those of any
         // single module.
-        val statements = Thresholds(coverageSummaryStmtLowThreshold.value, coverageSummaryStmtHighThreshold.value)
-        val branches = Thresholds(coverageSummaryBranchLowThreshold.value, coverageSummaryBranchHighThreshold.value)
+        val summarize = ScoverageProjectSummaryPlugin.summarize.value
         total(projects) match {
           case Some(metrics) =>
-            val total = Summary(metrics, statements, branches)
+            val total = summarize(metrics)
             val errors = validate(projects, scope, total)
             if (errors.nonEmpty) throw new MessageOnlyException(errors.mkString("\n"))
             for {
@@ -59,6 +64,24 @@ object ScoverageSummaryPlugin extends AutoPlugin {
                 thisProject.value.id + "' or any of its aggregated modules"
             )
         }
+        projects
+      },
+      // Depending on the value of coverageSummary rather than merely on its completion means the coverage data is
+      // deserialized once, however many tasks consume it within a single evaluation, and that the report is on disk
+      // before this task can fail.
+      coverageSummaryCheck := {
+        val projects = coverageSummary.value
+        val log = streams.value.log
+        val scope = thisProjectRef.value.project
+        val summarize = ScoverageProjectSummaryPlugin.summarize.value
+        incoherent(projects) foreach (message => log.warn(message))
+        total(projects) foreach { metrics =>
+          val failures = violations(projects, scope, summarize(metrics))
+          if (failures.nonEmpty) {
+            failures foreach (message => log.error(message))
+            throw new MessageOnlyException(s"Coverage is below the minimum in ${failures.size} case(s)")
+          }
+        }
       }
     )
 
@@ -67,15 +90,56 @@ object ScoverageSummaryPlugin extends AutoPlugin {
     projects.iterator.map(_.summary.metrics).reduceOption(_ + _)
 
   // Visible for testing
-  // Every module resolves its own thresholds, so all of them are validated and every violation is reported at once.
-  // `totalScope` labels the thresholds of the aggregating project; when that project is aggregated into the report as
+  // The total is checked as well as the modules. It is not implied by them: the total rate is a weighted mean of the
+  // module rates, so modules passing a shared minimum would guarantee it, but a module exempted with a minimum of its
+  // own can drag the total below the minimum of the aggregating project while every module still passes.
+  private[scoverage] def violations(projects: Seq[ProjectSummary], totalScope: String, total: Summary): Seq[String] =
+    scopes(projects, totalScope, total) flatMap { case (scope, summary) =>
+      violation(scope, "Statement", summary.metrics.statementRate, summary.minimum.statements).toSeq ++
+        violation(scope, "Branch", summary.metrics.branchRate, summary.minimum.branches)
+    }
+
+  // A metric with nothing to cover has no rate and cannot fail; the report renders it as a dash for the same reason.
+  private def violation(scope: String, metric: String, rate: Option[Float], minimum: Float): Option[String] =
+    rate filter (_ < minimum) map { rate =>
+      f"[$scope] $metric coverage is $rate%2.02f%%, below the required $minimum%2.02f%%"
+    }
+
+  // Visible for testing
+  // A minimum above the low threshold is legal but worth pointing out: the offending cell is rendered in yellow or
+  // green while the build fails, which is impossible to explain to whoever reads the report.
+  private[scoverage] def incoherent(projects: Seq[ProjectSummary]): Seq[String] =
+    projects flatMap { project =>
+      val summary = project.summary
+      incoherence(project.id, "Stmt", summary.minimum.statements, summary.statements.low).toSeq ++
+        incoherence(project.id, "Branch", summary.minimum.branches, summary.branches.low)
+    }
+
+  private def incoherence(scope: String, metric: String, minimum: Float, low: Float): Option[String] =
+    if (minimum <= low) None
+    else
+      Some(
+        f"[$scope] coverageSummary${metric}Minimum ($minimum%2.02f%%) is above coverageSummary${metric}LowThreshold " +
+          f"($low%2.02f%%), so the metric can fail the check without being rendered in red"
+      )
+
+  // Visible for testing
+  // Every module resolves its own values, so all of them are validated and every violation is reported at once.
+  // `totalScope` labels the values of the aggregating project; when that project is aggregated into the report as
   // well, the two labels coincide and the duplicate message collapses.
   private[scoverage] def validate(projects: Seq[ProjectSummary], totalScope: String, total: Summary): Seq[String] =
-    ((projects.map(project => project.id -> project.summary) :+ (totalScope -> total)) flatMap {
-      case (scope, summary) =>
-        (validateThresholds("Stmt", summary.statements).toSeq ++ validateThresholds("Branch", summary.branches))
-          .map(message => s"[$scope] $message")
+    (scopes(projects, totalScope, total) flatMap { case (scope, summary) =>
+      (validateThresholds("Stmt", summary.statements).toSeq ++
+        validateThresholds("Branch", summary.branches) ++
+        validateMinimum("Stmt", summary.minimum.statements) ++
+        validateMinimum("Branch", summary.minimum.branches)) map (message => s"[$scope] $message")
     }).distinct
+
+  private def scopes(
+      projects: Seq[ProjectSummary],
+      totalScope: String,
+      total: Summary
+  ): Seq[(String, Summary)] = projects.map(project => project.id -> project.summary) :+ (totalScope -> total)
 
   // Visible for testing
   // Coverage rates are always within [0, 100], so a threshold outside that range makes a color unreachable,
@@ -89,4 +153,9 @@ object ScoverageSummaryPlugin extends AutoPlugin {
         s"Inconsistent thresholds: coverageSummary${metric}LowThreshold (${thresholds.low}) and " +
           s"coverageSummary${metric}HighThreshold (${thresholds.high}) must satisfy 0 <= low <= high <= 100"
       )
+
+  // Visible for testing
+  private[scoverage] def validateMinimum(metric: String, minimum: Float): Option[String] =
+    if (0 <= minimum && minimum <= 100) None
+    else Some(s"coverageSummary${metric}Minimum ($minimum) must be within [0, 100]")
 }

--- a/plugin/src/main/scala/h8io/sbt/scoverage/Summary.scala
+++ b/plugin/src/main/scala/h8io/sbt/scoverage/Summary.scala
@@ -4,4 +4,4 @@ package h8io.sbt.scoverage
   * than being passed to a format separately, because every module resolves its own values and a table may therefore mix
   * several sets of them.
   */
-final case class Summary(metrics: Metrics, statements: Thresholds, branches: Thresholds)
+final case class Summary(metrics: Metrics, statements: Thresholds, branches: Thresholds, minimum: Minimum)

--- a/plugin/src/test/scala/h8io/sbt/scoverage/FormatTest.scala
+++ b/plugin/src/test/scala/h8io/sbt/scoverage/FormatTest.scala
@@ -5,10 +5,11 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 class FormatTest extends AnyFlatSpec with Matchers with MockFactory {
+  private val noMinimum = Minimum(0, 0)
   private val statements = Thresholds(0.3f, 0.8f)
   private val branches = Thresholds(0.1f, 0.5f)
 
-  private def summary(metrics: Metrics) = Summary(metrics, statements, branches)
+  private def summary(metrics: Metrics) = Summary(metrics, statements, branches, noMinimum)
 
   private val project = ProjectSummary("root", "single", summary(Metrics(12, 7, 1, 10, 5)))
   private val projects = Seq(
@@ -60,7 +61,7 @@ class FormatTest extends AnyFlatSpec with Matchers with MockFactory {
   }
 
   s"${Format.GitHubFlavoredMarkdown.name}" should "color statements and branches by their own thresholds" in {
-    val equalRates = Summary(Metrics(10, 5, 0, 10, 5), Thresholds(60, 80), Thresholds(20, 40))
+    val equalRates = Summary(Metrics(10, 5, 0, 10, 5), Thresholds(60, 80), Thresholds(20, 40), noMinimum)
     val rendered = Format.GitHubFlavoredMarkdown.render(equalRates)
     rendered should include("\\color{#f00}50.00")
     rendered should include("\\color{#0f0}50.00")
@@ -68,10 +69,11 @@ class FormatTest extends AnyFlatSpec with Matchers with MockFactory {
 
   it should "color every project by its own thresholds" in {
     val metrics = Metrics(10, 5, 0, 10, 5)
-    val strict = ProjectSummary("strict", "strict", Summary(metrics, Thresholds(60, 80), Thresholds(60, 80)))
-    val lenient = ProjectSummary("lenient", "lenient", Summary(metrics, Thresholds(20, 40), Thresholds(20, 40)))
+    val strict = ProjectSummary("strict", "strict", Summary(metrics, Thresholds(60, 80), Thresholds(60, 80), noMinimum))
+    val lenient =
+      ProjectSummary("lenient", "lenient", Summary(metrics, Thresholds(20, 40), Thresholds(20, 40), noMinimum))
     val rendered = Format.GitHubFlavoredMarkdown
-      .render(Seq(strict, lenient), Summary(metrics + metrics, Thresholds(40, 60), Thresholds(40, 60)))
+      .render(Seq(strict, lenient), Summary(metrics + metrics, Thresholds(40, 60), Thresholds(40, 60), noMinimum))
     rendered should include("\\color{#f00}50.00")
     rendered should include("\\color{#0f0}50.00")
     rendered should include("\\color{#ff0}50.00")

--- a/plugin/src/test/scala/h8io/sbt/scoverage/MetricsTest.scala
+++ b/plugin/src/test/scala/h8io/sbt/scoverage/MetricsTest.scala
@@ -7,4 +7,22 @@ class MetricsTest extends AnyFlatSpec with Matchers {
   "operator +" should "produce a correct sum of metrics" in {
     Metrics(42, 33, 5, 64, 47) + Metrics(77, 59, 2, 91, 37) shouldEqual Metrics(119, 92, 7, 155, 84)
   }
+
+  "rates" should "be percentages of the invoked code" in {
+    val metrics = Metrics(8, 2, 0, 5, 1)
+    metrics.statementRate shouldBe Some(25f)
+    metrics.branchRate shouldBe Some(20f)
+  }
+
+  it should "be undefined when there is nothing to cover" in {
+    val metrics = Metrics(0, 0, 0, 0, 0)
+    metrics.statementRate shouldBe None
+    metrics.branchRate shouldBe None
+  }
+
+  it should "be exactly 100 for fully covered code, so that a minimum of 100 is reachable" in {
+    val metrics = Metrics(7, 7, 0, 3, 3)
+    metrics.statementRate shouldBe Some(100f)
+    metrics.branchRate shouldBe Some(100f)
+  }
 }

--- a/plugin/src/test/scala/h8io/sbt/scoverage/ScoverageSummaryPluginTest.scala
+++ b/plugin/src/test/scala/h8io/sbt/scoverage/ScoverageSummaryPluginTest.scala
@@ -5,11 +5,12 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 class ScoverageSummaryPluginTest extends AnyFlatSpec with Matchers with OptionValues {
+  private val noMinimum = Minimum(0, 0)
   private val valid = Thresholds(50, 75)
   private val invalid = Thresholds(75, 50)
 
   private def project(id: String, statements: Thresholds = valid, branches: Thresholds = valid) =
-    ProjectSummary(id, id, Summary(Metrics(3, 2, 1, 5, 4), statements, branches))
+    ProjectSummary(id, id, Summary(Metrics(3, 2, 1, 5, 4), statements, branches, noMinimum))
 
   "total" should "return None for an empty sequence" in {
     ScoverageSummaryPlugin.total(Nil) shouldBe None
@@ -17,9 +18,9 @@ class ScoverageSummaryPluginTest extends AnyFlatSpec with Matchers with OptionVa
 
   it should "return a summary metric for a non-empty sequence" in {
     ScoverageSummaryPlugin.total(
-      ProjectSummary("project1", "project-1", Summary(Metrics(3, 2, 1, 5, 4), valid, valid)) ::
-        ProjectSummary("project2", "project-2", Summary(Metrics(7, 5, 3, 9, 7), valid, valid)) ::
-        ProjectSummary("project3", "project-3", Summary(Metrics(9, 7, 5, 13, 11), valid, valid)) ::
+      ProjectSummary("project1", "project-1", Summary(Metrics(3, 2, 1, 5, 4), valid, valid, noMinimum)) ::
+        ProjectSummary("project2", "project-2", Summary(Metrics(7, 5, 3, 9, 7), valid, valid, noMinimum)) ::
+        ProjectSummary("project3", "project-3", Summary(Metrics(9, 7, 5, 13, 11), valid, valid, noMinimum)) ::
         Nil
     ) shouldBe Some(Metrics(19, 14, 9, 27, 22))
   }
@@ -58,7 +59,7 @@ class ScoverageSummaryPluginTest extends AnyFlatSpec with Matchers with OptionVa
     )
   }
 
-  private val total = Summary(Metrics(3, 2, 1, 5, 4), valid, valid)
+  private val total = Summary(Metrics(3, 2, 1, 5, 4), valid, valid, noMinimum)
 
   "validate" should "accept modules which all resolve consistent thresholds" in {
     ScoverageSummaryPlugin.validate(Seq(project("a"), project("b")), "root", total) shouldBe empty
@@ -82,7 +83,7 @@ class ScoverageSummaryPluginTest extends AnyFlatSpec with Matchers with OptionVa
 
   it should "report the thresholds of the aggregating project" in {
     val errors =
-      ScoverageSummaryPlugin.validate(Nil, "root", Summary(Metrics(3, 2, 1, 5, 4), invalid, valid))
+      ScoverageSummaryPlugin.validate(Nil, "root", Summary(Metrics(3, 2, 1, 5, 4), invalid, valid, noMinimum))
     errors should have size 1
     errors.head should include("[root]")
   }
@@ -90,5 +91,74 @@ class ScoverageSummaryPluginTest extends AnyFlatSpec with Matchers with OptionVa
   it should "not report the aggregating project twice when it is aggregated into itself" in {
     val root = project("root", statements = invalid)
     ScoverageSummaryPlugin.validate(Seq(root), "root", root.summary) should have size 1
+  }
+
+  it should "reject a minimum outside the range of possible coverage rates" in {
+    ScoverageSummaryPlugin.validateMinimum("Stmt", 101) should not be empty
+    ScoverageSummaryPlugin.validateMinimum("Stmt", -1) should not be empty
+    ScoverageSummaryPlugin.validateMinimum("Stmt", 0) shouldBe None
+    ScoverageSummaryPlugin.validateMinimum("Stmt", 100) shouldBe None
+  }
+
+  // 5 of 10 statements and 5 of 10 branches, that is 50% of each
+  private def half(id: String, minimum: Minimum) =
+    ProjectSummary(id, id, Summary(Metrics(10, 5, 0, 10, 5), valid, valid, minimum))
+
+  private def totalOf(projects: Seq[ProjectSummary], minimum: Minimum) =
+    Summary(ScoverageSummaryPlugin.total(projects).value, valid, valid, minimum)
+
+  "violations" should "accept coverage above the minimum" in {
+    val projects = Seq(half("a", Minimum(40, 40)))
+    ScoverageSummaryPlugin.violations(projects, "root", totalOf(projects, Minimum(40, 40))) shouldBe empty
+  }
+
+  it should "accept coverage exactly at the minimum" in {
+    val projects = Seq(half("a", Minimum(50, 50)))
+    ScoverageSummaryPlugin.violations(projects, "root", totalOf(projects, Minimum(50, 50))) shouldBe empty
+  }
+
+  it should "reject coverage below the minimum" in {
+    val projects = Seq(half("a", Minimum(50.01f, 0)))
+    val failures = ScoverageSummaryPlugin.violations(projects, "root", totalOf(projects, Minimum(0, 0)))
+    failures should have size 1
+    failures.head should (include("[a]") and include("Statement"))
+  }
+
+  it should "reject every offending module and metric rather than stopping at the first" in {
+    val projects = Seq(half("a", Minimum(90, 90)), half("b", Minimum(0, 0)), half("c", Minimum(90, 0)))
+    ScoverageSummaryPlugin.violations(projects, "root", totalOf(projects, Minimum(0, 0))) should have size 3
+  }
+
+  it should "not fail a metric which has nothing to cover" in {
+    val branchless = ProjectSummary("a", "a", Summary(Metrics(10, 10, 0, 0, 0), valid, valid, Minimum(100, 100)))
+    val projects = Seq(branchless)
+    ScoverageSummaryPlugin.violations(projects, "root", totalOf(projects, Minimum(100, 100))) shouldBe empty
+  }
+
+  it should "let a minimum of 100 be reached by full coverage" in {
+    val full = ProjectSummary("a", "a", Summary(Metrics(10, 10, 0, 10, 10), valid, valid, Minimum(100, 100)))
+    val projects = Seq(full)
+    ScoverageSummaryPlugin.violations(projects, "root", totalOf(projects, Minimum(100, 100))) shouldBe empty
+  }
+
+  it should "reject a total dragged down by an exempted module even when every module passes" in {
+    val good = ProjectSummary("good", "good", Summary(Metrics(10, 10, 0, 10, 10), valid, valid, Minimum(90, 90)))
+    val exempt = ProjectSummary("exempt", "exempt", Summary(Metrics(10, 0, 0, 10, 0), valid, valid, Minimum(0, 0)))
+    val projects = Seq(good, exempt)
+    val failures = ScoverageSummaryPlugin.violations(projects, "root", totalOf(projects, Minimum(90, 90)))
+    failures should have size 2
+    all(failures) should include("[root]")
+  }
+
+  "incoherent" should "stay silent when the minimum is not above the low threshold" in {
+    ScoverageSummaryPlugin.incoherent(Seq(half("a", Minimum(50, 50)), half("b", Minimum(0, 0)))) shouldBe empty
+  }
+
+  it should "warn about a minimum above the low threshold" in {
+    val warnings = ScoverageSummaryPlugin.incoherent(Seq(half("a", Minimum(80, 50))))
+    warnings should have size 1
+    warnings.head should
+      (include("[a]") and include("coverageSummaryStmtMinimum") and
+        include("coverageSummaryStmtLowThreshold"))
   }
 }


### PR DESCRIPTION
## Summary

`coverageSummaryCheck` generates the report exactly as `coverageSummary` does and only then fails, so the report reaches the pull request whether coverage is sufficient or not — which was the point of the whole exercise.

Being a separate task also keeps the gate opt-in. Nothing starts failing on an upgrade; a build has to ask for the check by name.

```sbt
lazy val core = project.settings(coverageSummaryStmtMinimum := Some(90))
lazy val examples = project.settings(
  coverageSummaryStmtMinimum := Some(0),
  coverageSummaryBranchMinimum := Some(0)
)
```

### The minimum defaults to the low threshold, and why it is an `Option`

A minimum left undefined means the low threshold of the same metric **in the same module**, so that whatever fails the check is also rendered in red. That fallback cannot be expressed as a setting default, which was measured rather than assumed:

| mechanism | follows the module's own `low` | `ThisBuild / …Minimum` works |
|---|---|---|
| default in `globalSettings` | no — resolves the threshold in `Global` too | yes |
| `Def.derive` | yes | no — lands in the project scope, which outranks `ThisBuild` |
| `Option[Float]` resolved in the task | yes | yes |

Only the third gets both halves right, so the key is `settingKey[Option[Float]]` defaulting to `None`, and `getOrElse(low)` is applied in the task that already reads both values in the scope of its own module. `Option` settings are ordinary in sbt — this repository's own build has `versionScheme := Some("semver-spec")` — and `None` gains a meaning of its own: *the bar sits where the red line is*. The gate is switched off with an explicit `Some(0)`.

### Rates move to `Metrics`

The check needs the same arithmetic the report uses. Rather than compute it twice, `Metrics.statementRate` / `branchRate` become the single source, so a red cell and a failing module cannot disagree. They return `Option`, which also removes the reliance on every comparison with `NaN` being false for a metric with nothing to cover — correct today, but silently invertible by anyone writing `!(rate >= min)`.

### The total is checked too

Earlier I argued a total check was redundant, since the total rate is a weighted mean of the module rates and modules passing a shared minimum guarantee it. That stops holding once each module carries its own minimum: a module exempted with `Some(0)` can drag the total below the minimum of the aggregating project while every module still passes. So the total is checked against the aggregator's own values.

### Coherence warning

A minimum above the low threshold is legal — raising the gate should not force you to repaint the report — but it is warned about, because the offending cell is then yellow or green while the build fails, which is impossible to explain to whoever reads the comment.

## Test plan

- 37 unit tests on both matrix rows; `scalafmtSbtCheck` and `scalafmtCheckAll` clean
- new tests cover the strict comparison at the boundary, `Some(100)` reached by full coverage, a metric with nothing to cover never failing, every violation being reported rather than the first, the exempted-module-drags-the-total case, and the coherence warning
- verified end to end on a four-module scratch build against a locally published version:

  | module | configuration | required |
  |---|---|---|
  | `a` | only `coverageSummaryStmtLowThreshold := 90` | **90** — the undefined minimum followed the module's own threshold |
  | `b` | `coverageSummaryStmtMinimum := Some(10)` | 10 |
  | `c` | `coverageSummaryStmtMinimum := Some(80)`, low is 50 | 80, and the coherence warning fired |
  | — | `ThisBuild / coverageSummaryBranchMinimum := Some(0)` | branch checks went silent everywhere |

  all six violations were reported in one go, and `gfm.md` was on disk afterwards despite the failure

## Not included

`test.sh` still runs `+coverageSummary` and not `+coverageSummaryCheck`. This repository sits at about 10% statement coverage, so the default minimum would fail it immediately, and the publishing step in `h8io/gha` is still gated by an implicit `success()` — until that is fixed the check would fail the build without the comment ever appearing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)