### PR TITLE
Cover the remaining code with tests

### DIFF
--- a/plugin/src/test/scala/h8io/sbt/scoverage/FormatTest.scala
+++ b/plugin/src/test/scala/h8io/sbt/scoverage/FormatTest.scala
@@ -78,4 +78,22 @@ class FormatTest extends AnyFlatSpec with Matchers with MockFactory {
     rendered should include("\\color{#0f0}50.00")
     rendered should include("\\color{#ff0}50.00")
   }
+
+  it should "render the single project layout" in {
+    val thresholds = Thresholds(40, 60)
+    val single =
+      ProjectSummary("the-id", "the-name", Summary(Metrics(10, 5, 2, 10, 5), thresholds, thresholds, noMinimum))
+    val rendered = Format.GitHubFlavoredMarkdown.render(single)
+    rendered should (include("the-id") and include("the-name"))
+    rendered should include(">2</td>") // ignored statements
+    rendered should include("\\color{#ff0}50.00")
+  }
+
+  it should "render a dash for a metric which has nothing to cover" in {
+    val thresholds = Thresholds(40, 60)
+    val rendered =
+      Format.GitHubFlavoredMarkdown.render(Summary(Metrics(10, 5, 0, 0, 0), thresholds, thresholds, noMinimum))
+    rendered should include("\\textemdash")
+    rendered should include("\\color{#ff0}50.00")
+  }
 }

--- a/plugin/src/test/scala/h8io/sbt/scoverage/MetricsTest.scala
+++ b/plugin/src/test/scala/h8io/sbt/scoverage/MetricsTest.scala
@@ -2,8 +2,17 @@ package h8io.sbt.scoverage
 
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import scoverage.domain.ClassType
+import scoverage.domain.Coverage
+import scoverage.domain.Location
+import scoverage.domain.Statement
 
 class MetricsTest extends AnyFlatSpec with Matchers {
+  private def statement(id: Int, branch: Boolean, invoked: Boolean) = {
+    val location = Location("pkg", "Cls", "pkg.Cls", ClassType.Object, "method", "Cls.scala")
+    Statement(location, id, id, id, id, "", "", "", branch, if (invoked) 1 else 0)
+  }
+
   "operator +" should "produce a correct sum of metrics" in {
     Metrics(42, 33, 5, 64, 47) + Metrics(77, 59, 2, 91, 37) shouldEqual Metrics(119, 92, 7, 155, 84)
   }
@@ -24,5 +33,16 @@ class MetricsTest extends AnyFlatSpec with Matchers {
     val metrics = Metrics(7, 7, 0, 3, 3)
     metrics.statementRate shouldBe Some(100f)
     metrics.branchRate shouldBe Some(100f)
+  }
+
+  "apply" should "count the statements of a scoverage coverage" in {
+    val coverage = Coverage()
+    coverage.add(statement(1, branch = false, invoked = true))
+    coverage.add(statement(2, branch = false, invoked = false))
+    coverage.add(statement(3, branch = true, invoked = true))
+    coverage.add(statement(4, branch = true, invoked = false))
+    coverage.addIgnoredStatement(statement(5, branch = false, invoked = false))
+    // Ignored statements are held apart from the counted ones, so they stay out of the denominator
+    Metrics(coverage) shouldEqual Metrics(4, 2, 1, 2, 1)
   }
 }

--- a/plugin/src/test/scala/h8io/sbt/scoverage/PluginSettingsTest.scala
+++ b/plugin/src/test/scala/h8io/sbt/scoverage/PluginSettingsTest.scala
@@ -1,0 +1,47 @@
+package h8io.sbt.scoverage
+
+import h8io.sbt.scoverage.ScoverageSummaryPlugin.autoImport.*
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import sbt.*
+import sbt.plugins.JvmPlugin
+import scoverage.ScoverageSbtPlugin
+
+/** The scoping of the settings is what makes a threshold left undefined in a module fall back to `ThisBuild` and then
+  * to the global scope. That is not expressible in the types, so it is pinned down here.
+  */
+class PluginSettingsTest extends AnyFlatSpec with Matchers {
+  private def labels(settings: Seq[Def.Setting[?]]) = settings.map(_.key.key.label).toSet
+
+  "ScoverageProjectSummaryPlugin" should "be triggered by every JVM project" in {
+    // Otherwise the modules of a build would carry neither the summary task nor the global threshold defaults
+    ScoverageProjectSummaryPlugin.trigger shouldEqual PluginTrigger.AllRequirements
+    ScoverageProjectSummaryPlugin.requires shouldEqual JvmPlugin
+  }
+
+  it should "define the thresholds and the minimums globally rather than per project" in {
+    labels(ScoverageProjectSummaryPlugin.globalSettings) shouldEqual Set(
+      coverageSummaryStmtLowThreshold.key.label,
+      coverageSummaryStmtHighThreshold.key.label,
+      coverageSummaryBranchLowThreshold.key.label,
+      coverageSummaryBranchHighThreshold.key.label,
+      coverageSummaryStmtMinimum.key.label,
+      coverageSummaryBranchMinimum.key.label
+    )
+    // A project scoped default would outrank, and thereby mask, any ThisBuild override
+    labels(ScoverageProjectSummaryPlugin.projectSettings) shouldEqual
+      Set(ScoverageProjectSummaryPlugin.summary.key.label)
+  }
+
+  "ScoverageSummaryPlugin" should "be enabled explicitly on the aggregating project" in {
+    ScoverageSummaryPlugin.trigger shouldEqual PluginTrigger.NoTrigger
+    ScoverageSummaryPlugin.requires shouldEqual ScoverageSbtPlugin
+  }
+
+  it should "define both tasks and keep them from being aggregated" in {
+    val settings = ScoverageSummaryPlugin.projectSettings
+    labels(settings) should contain allOf (coverageSummary.key.label, coverageSummaryCheck.key.label)
+    // Without these the tasks would run once more for every aggregated module which enables the plugin
+    settings.count(_.key.key.label == Keys.aggregate.key.label) shouldEqual 2
+  }
+}

--- a/plugin/src/test/scala/h8io/sbt/scoverage/ProjectSummaryTest.scala
+++ b/plugin/src/test/scala/h8io/sbt/scoverage/ProjectSummaryTest.scala
@@ -1,0 +1,15 @@
+package h8io.sbt.scoverage
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import sbt.ProjectRef
+
+import java.io.File
+
+class ProjectSummaryTest extends AnyFlatSpec with Matchers {
+  "apply" should "take the id from the project reference" in {
+    val summary = Summary(Metrics(3, 2, 1, 5, 4), Thresholds(50, 75), Thresholds(50, 75), Minimum(0, 0))
+    val reference = ProjectRef(new File("build").toURI, "the-id")
+    ProjectSummary(reference, "the-name", summary) shouldEqual ProjectSummary("the-id", "the-name", summary)
+  }
+}


### PR DESCRIPTION
## Summary

| row | statements | branches |
|---|---|---|
| `plugin` (Scala 3.8.4) | 86.17% → **100%** | 95.24% → **100%** |
| `plugin2_12` (Scala 2.12.21) | 95.89% → **100%** | 95.24% → **100%** |

What was uncovered, found by reading `scoverage.xml` rather than guessing:

- `Format.render(project: ProjectSummary)` — the single project layout. The dispatch to it was verified with a mock, but it had never actually rendered anything. The largest gap by far, 28 of the 52 missed statements on the Scala 3 row.
- the dash rendered for a metric with nothing to cover
- `Metrics.apply(coverage: Coverage)` — the conversion from the scoverage domain, now driven by a hand-built `Coverage`, which also pins down that ignored statements stay out of the denominator
- `ProjectSummary.apply(ref, name, summary)`
- the plugin declarations themselves

The tests over the plugin declarations are not there for the coverage. The scoping of the settings is what makes a threshold left undefined in a module fall back to `ThisBuild` and then to the global scope; moving those defaults into project settings would silently mask every `ThisBuild` override and no type would object. Same for the disabled aggregation of the two tasks. Those tests fail if either is undone.

## What 100% does not mean here

The bodies of the sbt tasks are absent from the report altogether — not uncovered, but never instrumented. In `ScoverageSummaryPlugin.scala` the statement numbering jumps straight from line 30 to line 89, skipping `coverageSummary` and `coverageSummaryCheck` entirely, because their bodies are rewritten by the sbt macros before scoverage sees them.

So this figure covers the pure code and says nothing about the task wiring. That part stays verified the way it has been throughout: by running a real build against a locally published plugin.

## Test plan

- 45 unit tests pass on both matrix rows; `scalafmtSbtCheck` and `scalafmtCheckAll` clean
- `cleanFull; coverage; test; coverageReport` reports 100% for both metrics on both rows, and `coverageSummary` renders both in green

🤖 Generated with [Claude Code](https://claude.com/claude-code)