### PR TITLE
Wire the coverage gate into CI

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,6 +11,6 @@ permissions:
 jobs:
   release:
     secrets: inherit
-    uses: h8io/gha/.github/workflows/release.yaml@v4
+    uses: h8io/gha/.github/workflows/release.yaml@v5
     with:
       java-version: 17

--- a/.github/workflows/snapshot.yaml
+++ b/.github/workflows/snapshot.yaml
@@ -9,6 +9,6 @@ permissions:
 jobs:
   snapshot:
     secrets: inherit
-    uses: h8io/gha/.github/workflows/snapshot.yaml@v4
+    uses: h8io/gha/.github/workflows/snapshot.yaml@v5
     with:
       java-version: 17

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,6 +11,6 @@ on:
 jobs:
   test:
     secrets: inherit
-    uses: h8io/gha/.github/workflows/test.yaml@v4
+    uses: h8io/gha/.github/workflows/test.yaml@v5
     with:
       java-version: 17

--- a/build.sbt
+++ b/build.sbt
@@ -5,8 +5,6 @@ ThisBuild / coverageSummaryStmtLowThreshold := 90
 ThisBuild / coverageSummaryStmtHighThreshold := 95
 ThisBuild / coverageSummaryBranchLowThreshold := 90
 ThisBuild / coverageSummaryBranchHighThreshold := 95
-ThisBuild / coverageSummaryStmtMinimum := Some(90)
-ThisBuild / coverageSummaryBranchMinimum := Some(90)
 
 val plugin = projectMatrix.in(file("plugin"))
   .jvmPlatform(scalaVersions = Seq("3.8.4", "2.12.21"))

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,13 @@
 dynverSonatypeSnapshots := true
 dynverSeparator := "-"
 
+ThisBuild / coverageSummaryStmtLowThreshold := 90
+ThisBuild / coverageSummaryStmtHighThreshold := 95
+ThisBuild / coverageSummaryBranchLowThreshold := 90
+ThisBuild / coverageSummaryBranchHighThreshold := 95
+ThisBuild / coverageSummaryStmtMinimum := Some(90)
+ThisBuild / coverageSummaryBranchMinimum := Some(90)
+
 val plugin = projectMatrix.in(file("plugin"))
   .jvmPlatform(scalaVersions = Seq("3.8.4", "2.12.21"))
   .enablePlugins(SbtPlugin, ScoverageSummaryPlugin)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
 addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.12.0")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.6.2")
-addSbtPlugin("io.h8.sbt" % "sbt-scoverage-summary" % "1.1.2")
+addSbtPlugin("io.h8.sbt" % "sbt-scoverage-summary" % "2.0.0")

--- a/test.sh
+++ b/test.sh
@@ -2,4 +2,4 @@
 
 set -euxo pipefail
 
-sbt "scalafmtSbtCheck; scalafmtCheckAll; cleanFull; +coverage; +test; +coverageSummary; +coverageAggregate"
+sbt "scalafmtSbtCheck; scalafmtCheckAll; cleanFull; +coverage; +test; +coverageSummary; +coverageAggregate; +coverageSummaryCheck"


### PR DESCRIPTION
## Summary

The plugin is on Maven Central as 2.0.0 and `h8io/gha` is released as v5.0.1, so the three pieces built over the last few changes can be joined up:

| what | from | to |
|---|---|---|
| `project/plugins.sbt` | `sbt-scoverage-summary` 1.1.2 | 2.0.0 |
| `.github/workflows/{test,release,snapshot}.yaml` | `h8io/gha/…@v4` | `@v5` |
| `test.sh` | — | `+coverageSummaryCheck` |
| `build.sbt` | defaults | 90 / 95, gated at 90 |

## Why the command goes where it goes

```
scalafmtSbtCheck; scalafmtCheckAll; cleanFull; +coverage; +test; +coverageSummary; +coverageAggregate; +coverageSummaryCheck
```

`+coverageSummary` stays ahead of the check even though the check depends on it. That dependency only orders things *within one evaluation*; `+` runs a command across every row of the cross build, so a check placed first would fail on Scala 3 and leave the 2.12 report unwritten — exactly the half-a-report outcome this whole exercise was about avoiding.

`+coverageAggregate` stays ahead too, so the HTML report exists for `h8io/gha` to upload as an artifact even on a failing run.

## Thresholds

```sbt
ThisBuild / coverageSummaryStmtLowThreshold := 90
ThisBuild / coverageSummaryStmtHighThreshold := 95
ThisBuild / coverageSummaryBranchLowThreshold := 90
ThisBuild / coverageSummaryBranchHighThreshold := 95
```

Red below 90, green from 95, build fails below 90. No minimum is set: an unset one resolves to the low threshold of its own metric in its own module, which is the 90 wanted here.

That coincidence is the point rather than an accident. Everything which fails the build is rendered red and nothing else is, so the comment on a pull request explains the failure by itself. Had the thresholds been left at the default 50 / 75 with a minimum of 90, a module at 70% would have rendered yellow while failing the build — and the plugin would have said so on every run, through its own coherence warning.

## Test plan

- `./test.sh` green end to end against the released 2.0.0, exit 0, coverage 100% on both rows, both summaries written and rendered green against the new 95 bar
- no coherence warning, confirming `minimum <= low` holds
- the thresholds verified as resolved on both matrix rows through `ThisBuild` delegation:

  ```
  coverageSummaryStmtLowThreshold      plugin / plugin2_12   90.0
  coverageSummaryStmtHighThreshold     plugin / plugin2_12   95.0
  coverageSummaryBranchLowThreshold    plugin / plugin2_12   90.0
  coverageSummaryBranchHighThreshold   plugin / plugin2_12   95.0
  ```

- the effective minimum checked behaviourally rather than by printing the setting, which reads `None` by design since the fallback is applied in the task. With `FormatTest.scala` moved aside:

  ```
  [plugin]      Statement coverage is 26.60%, below the required 90.00%
  [plugin2_12]  Statement coverage is 31.51%, below the required 90.00%
  [plugin]      Branch coverage is 47.62%, below the required 90.00%
  ```

  The required 90 is the fallback at work. Every offending row and metric is reported at once rather than stopping at the first, exit 1. Restored afterwards, `./test.sh` green again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)